### PR TITLE
Release/r uolos2 009

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -18,6 +18,7 @@ additional_hostnames:
     - udenu.os2udoglaer
     - ungegarantien.os2udoglaer
     - udsynmodarbejdsliv.os2udoglaer
+    - udoglaer.roskilde.os2udoglaer
 additional_fqdns: []
 database:
     type: mariadb

--- a/README.md
+++ b/README.md
@@ -302,4 +302,4 @@ collaboration:
 This is done using Platform.sh CI/CD and Gitops.
 
 ### Deploy bumper
-This has been done 10 times
+This has been done 11 times

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae89a30b9af23092a0fe6cf416d6eb64",
+    "content-hash": "826b0810d70af67a61b7407a23fbb94b",
     "packages": [
         {
             "name": "algolia/places",
@@ -164,7 +164,7 @@
             "version": "1.8.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:bgrins/spectrum.git",
+                "url": "https://github.com/bgrins/spectrum.git",
                 "reference": "9aa028de7e8039c41ac792485a928edb97d4ac40"
             },
             "dist": {
@@ -3233,6 +3233,14 @@
                 {
                     "name": "agentrickard",
                     "homepage": "https://www.drupal.org/user/20975"
+                },
+                {
+                    "name": "danrod",
+                    "homepage": "https://www.drupal.org/user/19150"
+                },
+                {
+                    "name": "mably",
+                    "homepage": "https://www.drupal.org/user/3375160"
                 },
                 {
                     "name": "nonsie",

--- a/config/sync/core.entity_form_display.node.exercise.default.yml
+++ b/config/sync/core.entity_form_display.node.exercise.default.yml
@@ -58,7 +58,6 @@ third_party_settings:
         - field_target_group
         - field_activity_select
         - body
-        - field_purpose_exercise
       label: Beskrivelse
       region: content
       parent_name: ''
@@ -83,6 +82,7 @@ third_party_settings:
         - field_ackground_knowledge
         - field_activities
         - field_post_processing
+        - field_purpose_exercise
       label: 'Før, under og efter besøget'
       region: content
       parent_name: ''
@@ -227,7 +227,6 @@ third_party_settings:
         required_fields: true
     group_theme_subject:
       children:
-        - field_theme
         - field_focus
         - field_sustainability_goals
         - field_sustainability_goals_desc
@@ -474,7 +473,7 @@ content:
     third_party_settings: {  }
   field_post_processing:
     type: text_textarea
-    weight: 12
+    weight: 11
     region: content
     settings:
       rows: 5
@@ -515,7 +514,7 @@ content:
             selector: ''
   field_purpose_exercise:
     type: text_textarea
-    weight: 5
+    weight: 12
     region: content
     settings:
       rows: 5

--- a/config/sync/core.entity_form_display.node.junior_apprenticeship.default.yml
+++ b/config/sync/core.entity_form_display.node.junior_apprenticeship.default.yml
@@ -1,0 +1,750 @@
+uuid: e56bd387-cccc-475a-b0ed-25793fa974bc
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - image.style.medium
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - conditional_fields
+    - datetime
+    - dawa
+    - field_group
+    - focal_point
+    - maxlength
+    - metatag
+    - paragraphs
+    - path
+    - text
+    - workflow_buttons
+third_party_settings:
+  field_group:
+    group_practical_information:
+      children:
+        - field_quantity
+        - field_description_of_period
+        - field_duration_rte
+        - field_meeting_times
+        - field_todo_list
+        - field_banner
+      label: 'Praktisk information'
+      region: content
+      parent_name: ''
+      weight: 3
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_application:
+      children:
+        - field_open_for_application
+        - field_desc_application_procedure
+        - field_application_deadline
+        - field_application_title
+        - field_application_url
+        - field_application_email
+        - field_application_phone
+        - field_show_application_link
+      label: Ansøgning
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_location:
+      children:
+        - field_view_on_map
+        - group_alternative_address
+        - field_location_description
+        - field_p_number
+      label: Lokation
+      region: content
+      parent_name: ''
+      weight: 7
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_alternative_address:
+      children:
+        - field_location_name
+        - field_dawa_address
+      label: 'Alternativ adresse'
+      region: content
+      parent_name: group_location
+      weight: 75
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
+    group_video:
+      children:
+        - field_video_title
+        - field_video_description
+        - field_video
+      label: Video
+      region: content
+      parent_name: group_media
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
+    group_description:
+      children:
+        - title
+        - body
+        - field_purpose_internship
+        - field_expectations
+      label: Beskrivelse
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: 'open="open"'
+        effect: none
+        speed: fast
+        required_fields: true
+    group_industry_area_interest:
+      children:
+        - field_industry
+        - field_areas_of_interest
+        - field_education_path
+      label: 'Branche og interesseområde'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_media:
+      children:
+        - field_image
+        - group_video
+      label: Billeder/medier
+      region: content
+      parent_name: ''
+      weight: 5
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_materials:
+      children:
+        - field_materials
+      label: Materialer
+      region: content
+      parent_name: ''
+      weight: 6
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_related_courses:
+      children:
+        - field_related_courses
+      label: 'Relaterede forløb'
+      region: content
+      parent_name: ''
+      weight: 8
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_content_visibility:
+      children:
+        - field_exclude_from_search
+        - field_exclude_from_profile
+        - field_hide_contact_form
+        - field_domain_access
+      label: 'Visning af indhold'
+      region: content
+      parent_name: ''
+      weight: 9
+      format_type: html_element
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+id: node.junior_apprenticeship.default
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 2
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+      maxlength:
+        maxlength_js: null
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_summary: 82
+        maxlength_js_label_summary: 'Begrænset til @limit karakterer, tilgængelige: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
+  created:
+    type: datetime_timestamp
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_application_deadline:
+    type: datetime_default
+    weight: 65
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_application_email:
+    type: email_default
+    weight: 68
+    region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
+  field_application_phone:
+    type: string_textfield
+    weight: 69
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_application_title:
+    type: string_textfield
+    weight: 66
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_application_url:
+    type: string_textfield
+    weight: 67
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_areas_of_interest:
+    type: entity_reference_autocomplete
+    weight: 70
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_banner:
+    type: options_select
+    weight: 67
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_dawa_address:
+    type: dawa_address_autocomplete_widget
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings:
+      conditional_fields:
+        a04a554d-dbfd-4aab-a25a-473f5134e58a:
+          entity_type: node
+          bundle: internship
+          dependee: field_view_on_map
+          settings:
+            state: required
+            reset: false
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: show_alternative_address
+            effect: show
+            effect_options: {  }
+            selector: ''
+  field_desc_application_procedure:
+    type: text_textarea
+    weight: 64
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_description_of_period:
+    type: text_textarea
+    weight: 62
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_domain_access:
+    type: options_buttons
+    weight: 77
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_duration_rte:
+    type: text_textarea
+    weight: 64
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_education_path:
+    type: text_textarea
+    weight: 72
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_exclude_from_profile:
+    type: boolean_checkbox
+    weight: 75
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_exclude_from_search:
+    type: boolean_checkbox
+    weight: 74
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_expectations:
+    type: text_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_hide_contact_form:
+    type: boolean_checkbox
+    weight: 76
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_image:
+    type: image_focal_point
+    weight: 7
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: medium
+      preview_link: true
+      offsets: '50,50'
+    third_party_settings: {  }
+  field_industry:
+    type: options_buttons
+    weight: 69
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_location_description:
+    type: text_textarea
+    weight: 76
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_location_name:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_materials:
+    type: paragraphs
+    weight: 6
+    region: content
+    settings:
+      title: Materiale
+      title_plural: Materialer
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: material
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        convert: '0'
+        duplicate: '0'
+    third_party_settings: {  }
+  field_meeting_times:
+    type: text_textarea
+    weight: 65
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_meta_tags:
+    type: metatag_firehose
+    weight: 20
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
+  field_open_for_application:
+    type: boolean_checkbox
+    weight: 63
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_p_number:
+    type: string_textfield
+    weight: 77
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_purpose_internship:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_quantity:
+    type: string_textfield
+    weight: 61
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_related_courses:
+    type: entity_reference_autocomplete
+    weight: 8
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_show_application_link:
+    type: boolean_checkbox
+    weight: 70
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_todo_list:
+    type: text_textarea
+    weight: 66
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_video:
+    type: paragraphs
+    weight: 8
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        convert: '0'
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_video_description:
+    type: text_textarea
+    weight: 7
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_video_title:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_view_on_map:
+    type: options_buttons
+    weight: 74
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  group_alternative_address:
+    weight: 27
+    region: content
+    settings: {  }
+    third_party_settings:
+      conditional_fields:
+        8b4e304e-cd58-46b9-8b0d-a4683cf7ba86:
+          entity_type: node
+          bundle: internship
+          dependee: field_view_on_map
+          settings:
+            state: visible
+            reset: false
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: show_alternative_address
+            effect: show
+            effect_options: {  }
+            selector: ''
+            inheritance:
+              propagate: '0'
+              apply_to_parent: '0'
+              recurse: '0'
+  langcode:
+    type: language_select
+    weight: 10
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: workflow_buttons
+    weight: 18
+    region: content
+    settings:
+      show_current_state: false
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 14
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 19
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings:
+      maxlength:
+        maxlength_js: 45
+        maxlength_js_label: 'Begrænset til @limit karakterer, tilgængelige: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
+  uid:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_domain_all_affiliates: true
+  field_pretix_email_notifiers: true
+  field_pretix_event_short_form: true
+  field_pretix_shop_url: true
+  field_pretix_template_event: true
+  field_pretix_widget_type: true
+  workbench_reviewer: true

--- a/config/sync/core.entity_form_display.node.junior_apprenticeship.pretix_settings.yml
+++ b/config/sync/core.entity_form_display.node.junior_apprenticeship.pretix_settings.yml
@@ -1,0 +1,396 @@
+uuid: 2b4459c0-53b7-4c43-9bd8-b280ae95dbcc
+langcode: da
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.node.pretix_settings
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - node.type.junior_apprenticeship
+  module:
+    - field_group
+    - link
+third_party_settings:
+  field_group:
+    group_practical_information:
+      children:
+        - field_banner
+        - field_description_of_period
+        - field_duration_rte
+        - field_meeting_times
+        - field_quantity
+        - field_todo_list
+      label: 'Praktisk information'
+      region: hidden
+      parent_name: ''
+      weight: 5
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_application:
+      children:
+        - field_application_deadline
+        - field_application_email
+        - field_application_phone
+        - field_application_title
+        - field_application_url
+        - field_desc_application_procedure
+        - field_show_application_link
+      label: Ansøgning
+      region: hidden
+      parent_name: ''
+      weight: 7
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_location:
+      children:
+        - field_location_description
+        - field_view_on_map
+        - group_alternative_address
+      label: Lokation
+      region: hidden
+      parent_name: ''
+      weight: 9
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_alternative_address:
+      children:
+        - field_location_city
+        - field_location_name
+        - field_location_street
+        - field_location_zipcode
+      label: 'Alternativ adresse'
+      region: hidden
+      parent_name: group_location
+      weight: 17
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
+    group_video:
+      children:
+        - field_video
+        - field_video_description
+        - field_video_title
+      label: Video
+      region: hidden
+      parent_name: group_media
+      weight: 8
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: true
+    group_description:
+      children:
+        - title
+        - body
+        - field_expectations
+        - field_purpose_internship
+      label: Beskrivelse
+      region: hidden
+      parent_name: ''
+      weight: 3
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: 'open="open"'
+        effect: none
+        speed: fast
+        required_fields: true
+    group_industry_area_interest:
+      children:
+        - field_areas_of_interest
+        - field_education_path
+        - field_industry
+        - field_theme
+      label: 'Branche og interesseområde'
+      region: hidden
+      parent_name: ''
+      weight: 4
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_media:
+      children:
+        - field_image
+        - group_video
+      label: Billeder/medier
+      region: hidden
+      parent_name: ''
+      weight: 8
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_materials:
+      children:
+        - field_materials
+      label: Materialer
+      region: hidden
+      parent_name: ''
+      weight: 6
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_related_courses:
+      children:
+        - field_related_courses
+      label: 'Relaterede forløb'
+      region: hidden
+      parent_name: ''
+      weight: 11
+      format_type: html_element
+      format_settings:
+        classes: trailer
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+    group_content_visibility:
+      children:
+        - field_domain_access
+        - field_exclude_from_profile
+        - field_exclude_from_search
+      label: 'Visning af indhold'
+      region: hidden
+      parent_name: ''
+      weight: 12
+      format_type: html_element
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        element: details
+        show_label: true
+        label_element: summary
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        required_fields: true
+id: node.junior_apprenticeship.pretix_settings
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: pretix_settings
+content:
+  field_pretix_email_notifiers:
+    type: email_default
+    weight: 0
+    region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
+  field_pretix_shop_url:
+    type: link_default
+    weight: -2
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_pretix_widget_type:
+    type: options_select
+    weight: -1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  group_alternative_address:
+    weight: 27
+    region: content
+    settings: {  }
+    third_party_settings:
+      conditional_fields:
+        8b4e304e-cd58-46b9-8b0d-a4683cf7ba86:
+          entity_type: node
+          bundle: internship
+          dependee: field_view_on_map
+          settings:
+            state: visible
+            reset: false
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: show_alternative_address
+            effect: show
+            effect_options: {  }
+            selector: ''
+            inheritance:
+              propagate: '0'
+              apply_to_parent: '0'
+              recurse: '0'
+hidden:
+  body: true
+  created: true
+  field_application_deadline: true
+  field_application_email: true
+  field_application_phone: true
+  field_application_title: true
+  field_application_url: true
+  field_areas_of_interest: true
+  field_banner: true
+  field_dawa_address: true
+  field_desc_application_procedure: true
+  field_description_of_period: true
+  field_domain_access: true
+  field_domain_all_affiliates: true
+  field_duration_rte: true
+  field_education_path: true
+  field_exclude_from_profile: true
+  field_exclude_from_search: true
+  field_expectations: true
+  field_hide_contact_form: true
+  field_image: true
+  field_industry: true
+  field_location_description: true
+  field_location_name: true
+  field_materials: true
+  field_meeting_times: true
+  field_meta_tags: true
+  field_open_for_application: true
+  field_p_number: true
+  field_pretix_event_short_form: true
+  field_pretix_template_event: true
+  field_purpose_internship: true
+  field_quantity: true
+  field_related_courses: true
+  field_show_application_link: true
+  field_todo_list: true
+  field_video: true
+  field_video_description: true
+  field_video_title: true
+  field_view_on_map: true
+  langcode: true
+  moderation_state: true
+  path: true
+  promote: true
+  simple_sitemap: true
+  status: true
+  sticky: true
+  title: true
+  uid: true
+  url_redirects: true
+  workbench_reviewer: true

--- a/config/sync/core.entity_form_display.node.transport_pool_form.default.yml
+++ b/config/sync/core.entity_form_display.node.transport_pool_form.default.yml
@@ -112,8 +112,8 @@ third_party_settings:
         required_fields: true
     group_tpf_contact_info:
       children:
-        - field_rfc_name
         - field_rfc_mail
+        - field_rfc_name
         - field_rfc_phone
         - field_tpf_message
       label: Kontaktinformation
@@ -214,7 +214,7 @@ content:
     third_party_settings: {  }
   field_rfc_name:
     type: string_textfield
-    weight: 16
+    weight: 18
     region: content
     settings:
       size: 60
@@ -222,7 +222,7 @@ content:
     third_party_settings: {  }
   field_rfc_phone:
     type: string_textfield
-    weight: 18
+    weight: 19
     region: content
     settings:
       size: 60
@@ -288,7 +288,7 @@ content:
     third_party_settings: {  }
   field_tpf_message:
     type: string_textarea
-    weight: 19
+    weight: 20
     region: content
     settings:
       rows: 5

--- a/config/sync/core.entity_view_display.node.junior_apprenticeship.default.yml
+++ b/config/sync/core.entity_view_display.node.junior_apprenticeship.default.yml
@@ -1,0 +1,364 @@
+uuid: 89938c30-ca03-485b-840e-cb3cc0980e38
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - image.style.medium
+    - node.type.junior_apprenticeship
+  module:
+    - datetime
+    - dawa
+    - entity_reference_revisions
+    - image
+    - metatag
+    - options
+    - text
+    - user
+id: node.junior_apprenticeship.default
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_application_deadline:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_application_email:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_application_phone:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_application_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_application_url:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_areas_of_interest:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_banner:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 18
+    region: content
+  field_dawa_address:
+    type: dawa_address_autocomplete_formatter
+    label: above
+    settings:
+      display_as: full
+      include_country: true
+    third_party_settings: {  }
+    weight: 56
+    region: content
+  field_desc_application_procedure:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 28
+    region: content
+  field_description_of_period:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 24
+    region: content
+  field_duration_rte:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 29
+    region: content
+  field_education_path:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 27
+    region: content
+  field_exclude_from_profile:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 34
+    region: content
+  field_exclude_from_search:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 33
+    region: content
+  field_expectations:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 21
+    region: content
+  field_hide_contact_form:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 54
+    region: content
+  field_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  field_industry:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_location_description:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 23
+    region: content
+  field_location_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 14
+    region: content
+  field_materials:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 12
+    region: content
+  field_meeting_times:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 25
+    region: content
+  field_meta_tags:
+    type: metatag_empty_formatter
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_open_for_application:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 57
+    region: content
+  field_p_number:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 55
+    region: content
+  field_purpose_internship:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 30
+    region: content
+  field_quantity:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 35
+    region: content
+  field_related_courses:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 32
+    region: content
+  field_show_application_link:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_todo_list:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 26
+    region: content
+  field_video:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 31
+    region: content
+  field_video_description:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 20
+    region: content
+  field_video_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 19
+    region: content
+  field_view_on_map:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 13
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  content_moderation_control: true
+  field_domain_access: true
+  field_domain_all_affiliates: true
+  field_pretix_email_notifiers: true
+  field_pretix_event_short_form: true
+  field_pretix_shop_url: true
+  field_pretix_template_event: true
+  field_pretix_widget_type: true
+  langcode: true
+  search_api_excerpt: true
+  workbench_reviewer: true
+  workflow_buttons: true

--- a/config/sync/core.entity_view_display.node.junior_apprenticeship.teaser.yml
+++ b/config/sync/core.entity_view_display.node.junior_apprenticeship.teaser.yml
@@ -1,0 +1,121 @@
+uuid: 53d9a1db-0b8e-4848-84e4-06426aeab0f5
+langcode: da
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - node.type.junior_apprenticeship
+  module:
+    - text
+    - user
+id: node.junior_apprenticeship.teaser
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_application_deadline: true
+  field_application_email: true
+  field_application_phone: true
+  field_application_title: true
+  field_application_url: true
+  field_areas_of_interest: true
+  field_banner: true
+  field_dawa_address: true
+  field_desc_application_procedure: true
+  field_description_of_period: true
+  field_domain_access: true
+  field_domain_all_affiliates: true
+  field_duration_rte: true
+  field_education_path: true
+  field_exclude_from_profile: true
+  field_exclude_from_search: true
+  field_expectations: true
+  field_hide_contact_form: true
+  field_image: true
+  field_industry: true
+  field_location_description: true
+  field_location_name: true
+  field_materials: true
+  field_meeting_times: true
+  field_meta_tags: true
+  field_open_for_application: true
+  field_p_number: true
+  field_pretix_email_notifiers: true
+  field_pretix_event_short_form: true
+  field_pretix_shop_url: true
+  field_pretix_template_event: true
+  field_pretix_widget_type: true
+  field_purpose_internship: true
+  field_quantity: true
+  field_related_courses: true
+  field_show_application_link: true
+  field_todo_list: true
+  field_video: true
+  field_video_description: true
+  field_video_title: true
+  field_view_on_map: true
+  langcode: true
+  search_api_excerpt: true
+  workbench_reviewer: true
+  workflow_buttons: true

--- a/config/sync/core.entity_view_display.node.page.full.yml
+++ b/config/sync/core.entity_view_display.node.page.full.yml
@@ -75,6 +75,7 @@ third_party_settings:
           - 'views_block:latest_news-block_1'
           - 'views_block:content_search-block_1'
           - 'views_block:course_providers-block_2'
+          - 'views_block:content_search-block_10'
           - 'views_block:content_search-block_2'
           - 'views_block:content_search-block_3'
           - 'views_block:content_search-block_5'

--- a/config/sync/domain.record.api_udoglaer_roskilde_dk.yml
+++ b/config/sync/domain.record.api_udoglaer_roskilde_dk.yml
@@ -1,0 +1,11 @@
+uuid: 17718762-63b4-4e8f-b348-6ecf49af0e42
+langcode: da
+status: true
+dependencies: {  }
+id: api_udoglaer_roskilde_dk
+domain_id: 4157052
+hostname: api.udoglaer.roskilde.dk
+name: udoglaer.roskilde.dk
+scheme: variable
+weight: 12
+is_default: false

--- a/config/sync/domain_alias.alias.api_staging_udoglaer_roskilde_dk.yml
+++ b/config/sync/domain_alias.alias.api_staging_udoglaer_roskilde_dk.yml
@@ -1,0 +1,9 @@
+uuid: a8c4acd8-5765-4bd3-af59-734a3dc14c85
+langcode: da
+status: true
+dependencies: {  }
+id: api_staging_udoglaer_roskilde_dk
+domain_id: api_udoglaer_roskilde_dk
+pattern: api-staging.udoglaer.roskilde.dk
+redirect: 0
+environment: staging

--- a/config/sync/domain_alias.alias.api_udoglaer_roskilde_dk_staging_5em2ouy_4yghg26zberzk_eu_5_plat.yml
+++ b/config/sync/domain_alias.alias.api_udoglaer_roskilde_dk_staging_5em2ouy_4yghg26zberzk_eu_5_plat.yml
@@ -1,0 +1,9 @@
+uuid: 2d672ad3-a5c4-4673-9297-fec38991c70a
+langcode: da
+status: true
+dependencies: {  }
+id: api_udoglaer_roskilde_dk_staging_5em2ouy_4yghg26zberzk_eu_5_plat
+domain_id: api_udoglaer_roskilde_dk
+pattern: api.udoglaer.roskilde.dk.staging-5em2ouy-4yghg26zberzk.eu-5.platformsh.site
+redirect: 0
+environment: staging

--- a/config/sync/domain_alias.alias.udoglaer_roskilde_os2udoglaer_localhost.yml
+++ b/config/sync/domain_alias.alias.udoglaer_roskilde_os2udoglaer_localhost.yml
@@ -1,0 +1,9 @@
+uuid: 7e59e262-b0a3-46e7-a2e6-3e00fe23a821
+langcode: da
+status: true
+dependencies: {  }
+id: udoglaer_roskilde_os2udoglaer_localhost
+domain_id: api_udoglaer_roskilde_dk
+pattern: udoglaer.roskilde.os2udoglaer.localhost
+redirect: 0
+environment: local

--- a/config/sync/domain_login_restrict.settings.yml
+++ b/config/sync/domain_login_restrict.settings.yml
@@ -30,3 +30,33 @@ domain_login_restrict_assign_role_api_rum_thisted_dk:
   monitor: 0
   bypass_workflow: 0
   rest_api: 0
+domain_login_restrict_role_api_udoglaer_roskilde_dk:
+  anonymous: 0
+  authenticated: 0
+  administrator: 0
+  webmaster: 0
+  editor: 0
+  course_provider: 0
+  corporation: 0
+  institution: 0
+  school: 0
+  place_of_visit: 0
+  theater_contact: 0
+  monitor: 0
+  bypass_workflow: 0
+  rest_api: 0
+domain_login_restrict_assign_role_api_udoglaer_roskilde_dk:
+  anonymous: 0
+  authenticated: 0
+  administrator: 0
+  webmaster: 0
+  editor: 0
+  course_provider: 0
+  corporation: 0
+  institution: 0
+  school: 0
+  place_of_visit: 0
+  theater_contact: 0
+  monitor: 0
+  bypass_workflow: 0
+  rest_api: 0

--- a/config/sync/facets.facet.junior_apprenticeship_areas_of_interest.yml
+++ b/config/sync/facets.facet.junior_apprenticeship_areas_of_interest.yml
@@ -1,0 +1,79 @@
+uuid: d020261b-64b0-4d2d-8795-ed62b2be638b
+langcode: da
+status: true
+dependencies:
+  config:
+    - search_api.index.search
+    - views.view.content_search
+  module:
+    - search_api
+id: junior_apprenticeship_areas_of_interest
+name: Interesseområde
+weight: -2
+min_count: 0
+missing: false
+missing_label: others
+url_alias: jaaoi
+facet_source_id: 'search_api:views_block__content_search__block_10'
+field_identifier: field_areas_of_interest
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: checkbox
+  config:
+    show_numbers: false
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Vis alle'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: -10
+    settings:
+      sort: ASC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: -7
+    settings:
+      sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  term_weight_widget_order:
+    processor_id: term_weight_widget_order
+    weights:
+      sort: -8
+    settings:
+      sort: ASC
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.junior_apprenticeship_company.yml
+++ b/config/sync/facets.facet.junior_apprenticeship_company.yml
@@ -1,0 +1,98 @@
+uuid: 8c538e01-a941-4604-a281-d5c18f16451f
+langcode: da
+status: true
+dependencies:
+  config:
+    - search_api.index.search
+    - views.view.content_search
+  module:
+    - search_api
+id: junior_apprenticeship_company
+name: Virksomhed
+weight: 0
+min_count: 1
+missing: false
+missing_label: others
+url_alias: jac
+facet_source_id: 'search_api:views_block__content_search__block_10'
+field_identifier: uid
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: checkbox
+  config:
+    show_numbers: false
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Vis alle'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: false
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: ASC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  uid_to_field_name_callback:
+    processor_id: uid_to_field_name_callback
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+  user_domain_access_filter:
+    processor_id: user_domain_access_filter
+    weights:
+      build: 1
+    settings: {  }
+  user_role_filter:
+    processor_id: user_role_filter
+    weights:
+      build: 2
+    settings:
+      roles:
+        corporation: corporation
+        anonymous: 0
+        authenticated: 0
+        administrator: 0
+        webmaster: 0
+        editor: 0
+        course_provider: 0
+        institution: 0
+        school: 0
+        place_of_visit: 0
+        theater_contact: 0
+        monitor: 0
+        bypass_workflow: 0
+        rest_api: 0

--- a/config/sync/facets.facet.junior_apprenticeship_company_guarantee_partner.yml
+++ b/config/sync/facets.facet.junior_apprenticeship_company_guarantee_partner.yml
@@ -1,0 +1,77 @@
+uuid: 5e136a9b-3c26-4b1d-ab88-e227dabd46fb
+langcode: da
+status: true
+dependencies:
+  config:
+    - search_api.index.search
+    - views.view.content_search
+  module:
+    - search_api
+id: junior_apprenticeship_company_guarantee_partner
+name: Garantipartner
+weight: 1
+min_count: 0
+missing: false
+missing_label: others
+url_alias: jacgp
+facet_source_id: 'search_api:views_block__content_search__block_10'
+field_identifier: uid_field_guarantee_partner
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: checkbox
+  config:
+    show_numbers: false
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Vis alle'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: false
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: ASC
+  boolean_empty_option:
+    processor_id: boolean_empty_option
+    weights:
+      pre_query: 70
+      build: 35
+    settings:
+      on_value: 'Juniormesterlærer ved garantipartner'
+      off_value: ''
+      all_value: 'Alle juniormesterlærer'
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.junior_apprenticeship_industry.yml
+++ b/config/sync/facets.facet.junior_apprenticeship_industry.yml
@@ -8,14 +8,14 @@ dependencies:
   module:
     - search_api
 id: junior_apprenticeship_industry
-name: Brancher
+name: Branche
 weight: -3
 min_count: 0
 missing: false
 missing_label: others
 url_alias: jai
 facet_source_id: 'search_api:views_block__content_search__block_10'
-field_identifier: field_brancher
+field_identifier: field_industry
 query_operator: or
 hard_limit: 0
 exclude: false
@@ -39,7 +39,7 @@ widget:
       show_more_label: 'Show more'
 empty_behavior:
   behavior: none
-only_visible_when_facet_source_is_visible: true
+only_visible_when_facet_source_is_visible: false
 show_only_one_result: false
 show_title: false
 processor_configs:

--- a/config/sync/facets.facet.junior_apprenticeship_industry.yml
+++ b/config/sync/facets.facet.junior_apprenticeship_industry.yml
@@ -1,0 +1,79 @@
+uuid: cee2818d-2276-433f-897f-a5d90ccd33ab
+langcode: da
+status: true
+dependencies:
+  config:
+    - search_api.index.search
+    - views.view.content_search
+  module:
+    - search_api
+id: junior_apprenticeship_industry
+name: Brancher
+weight: -3
+min_count: 0
+missing: false
+missing_label: others
+url_alias: jai
+facet_source_id: 'search_api:views_block__content_search__block_10'
+field_identifier: field_brancher
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: checkbox
+  config:
+    show_numbers: false
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Vis alle'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: -10
+    settings:
+      sort: ASC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: -7
+    settings:
+      sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  term_weight_widget_order:
+    processor_id: term_weight_widget_order
+    weights:
+      sort: -8
+    settings:
+      sort: ASC
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.junior_apprenticeship_open_for_application.yml
+++ b/config/sync/facets.facet.junior_apprenticeship_open_for_application.yml
@@ -1,0 +1,75 @@
+uuid: bf8f430d-9255-4a3f-86bf-cfefe9fcfa24
+langcode: da
+status: true
+dependencies:
+  config:
+    - search_api.index.search
+    - views.view.content_search
+  module:
+    - search_api
+id: junior_apprenticeship_open_for_application
+name: 'Åben for ansøgning'
+weight: 2
+min_count: 1
+missing: false
+missing_label: others
+url_alias: jaofa
+facet_source_id: 'search_api:views_block__content_search__block_10'
+field_identifier: field_open_for_application
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: checkbox
+  config:
+    show_numbers: false
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Vis alle'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: false
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: ASC
+  boolean_item:
+    processor_id: boolean_item
+    weights:
+      build: 35
+    settings:
+      on_value: Ja
+      off_value: Nej
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.junior_apprenticeship_post_number_and_city.yml
+++ b/config/sync/facets.facet.junior_apprenticeship_post_number_and_city.yml
@@ -1,0 +1,68 @@
+uuid: 2e4ca1b3-d994-45d7-b04c-cf81e086972e
+langcode: da
+status: true
+dependencies:
+  config:
+    - search_api.index.search
+    - views.view.content_search
+  module:
+    - search_api
+id: junior_apprenticeship_post_number_and_city
+name: 'Postnummer og by'
+weight: -1
+min_count: 1
+missing: false
+missing_label: others
+url_alias: japnac
+facet_source_id: 'search_api:views_block__content_search__block_10'
+field_identifier: post_number_city
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: checkbox
+  config:
+    show_numbers: false
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Vis alle'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: false
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: ASC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet_source.search_api__views_block__content_search__block_10.yml
+++ b/config/sync/facets.facet_source.search_api__views_block__content_search__block_10.yml
@@ -1,0 +1,9 @@
+uuid: 400af7ec-43e6-4223-90bd-c8f97dbcfbcc
+langcode: da
+status: true
+dependencies: {  }
+id: search_api__views_block__content_search__block_10
+name: 'search_api:views_block__content_search__block_10'
+filter_key: null
+url_processor: query_string
+breadcrumb: {  }

--- a/config/sync/field.field.node.course.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.course.field_exclude_from_search.yml
@@ -9,7 +9,7 @@ id: node.course.field_exclude_from_search
 field_name: field_exclude_from_search
 entity_type: node
 bundle: course
-label: 'Vis ikke i intern søgning'
+label: 'Vis ikke i søgning'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.course_educators.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.course_educators.field_exclude_from_search.yml
@@ -9,7 +9,7 @@ id: node.course_educators.field_exclude_from_search
 field_name: field_exclude_from_search
 entity_type: node
 bundle: course_educators
-label: 'Vis ikke i intern søgning'
+label: 'Vis ikke i søgning'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.exercise.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.exercise.field_exclude_from_search.yml
@@ -9,7 +9,7 @@ id: node.exercise.field_exclude_from_search
 field_name: field_exclude_from_search
 entity_type: node
 bundle: exercise
-label: 'Vis ikke i intern søgning'
+label: 'Vis ikke i søgning'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.internship.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.internship.field_exclude_from_search.yml
@@ -9,7 +9,7 @@ id: node.internship.field_exclude_from_search
 field_name: field_exclude_from_search
 entity_type: node
 bundle: internship
-label: 'Vis ikke i intern søgning'
+label: 'Vis ikke i søgning'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.junior_apprenticeship.body.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.body.yml
@@ -1,0 +1,31 @@
+uuid: 611b5327-20bf-4034-a50a-5656d75ebdaa
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.body
+field_name: body
+entity_type: node
+bundle: junior_apprenticeship
+label: Beskrivelse
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+  allowed_formats:
+    - basic_html
+field_type: text_with_summary

--- a/config/sync/field.field.node.junior_apprenticeship.field_application_deadline.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_application_deadline.yml
@@ -1,0 +1,21 @@
+uuid: e14b8af2-052b-4964-8523-7ba4ec9634a7
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_application_deadline
+    - node.type.junior_apprenticeship
+  module:
+    - datetime
+id: node.junior_apprenticeship.field_application_deadline
+field_name: field_application_deadline
+entity_type: node
+bundle: junior_apprenticeship
+label: Ansøgningsfrist
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.junior_apprenticeship.field_application_email.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_application_email.yml
@@ -1,0 +1,19 @@
+uuid: 56f4af6e-e2f5-4a7b-a400-79e9da668e16
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_application_email
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_application_email
+field_name: field_application_email
+entity_type: node
+bundle: junior_apprenticeship
+label: Email
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/sync/field.field.node.junior_apprenticeship.field_application_phone.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_application_phone.yml
@@ -1,0 +1,19 @@
+uuid: d07a9beb-e023-4ef9-87f4-2d64d8406ce4
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_application_phone
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_application_phone
+field_name: field_application_phone
+entity_type: node
+bundle: junior_apprenticeship
+label: Tlf.nr.
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_application_title.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_application_title.yml
@@ -1,0 +1,19 @@
+uuid: 26fa30bb-cf50-4010-8ee5-a004e2115153
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_application_title
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_application_title
+field_name: field_application_title
+entity_type: node
+bundle: junior_apprenticeship
+label: Linktekst
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_application_url.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_application_url.yml
@@ -1,0 +1,19 @@
+uuid: 3a4fff9b-d78d-436b-9121-325ed83eef13
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_application_url
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_application_url
+field_name: field_application_url
+entity_type: node
+bundle: junior_apprenticeship
+label: URL
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_areas_of_interest.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_areas_of_interest.yml
@@ -1,0 +1,29 @@
+uuid: 2fda5e04-abbd-4133-9e6a-926cf288b342
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_areas_of_interest
+    - node.type.junior_apprenticeship
+    - taxonomy.vocabulary.areas_of_interest
+id: node.junior_apprenticeship.field_areas_of_interest
+field_name: field_areas_of_interest
+entity_type: node
+bundle: junior_apprenticeship
+label: Interesseområde
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      areas_of_interest: areas_of_interest
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.junior_apprenticeship.field_banner.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_banner.yml
@@ -1,0 +1,29 @@
+uuid: 75738fef-bf5e-4ce8-a90c-cc4e79b2d58a
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_banner
+    - node.type.junior_apprenticeship
+    - taxonomy.vocabulary.banner
+id: node.junior_apprenticeship.field_banner
+field_name: field_banner
+entity_type: node
+bundle: junior_apprenticeship
+label: Banner
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      banner: banner
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.junior_apprenticeship.field_dawa_address.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_dawa_address.yml
@@ -1,0 +1,21 @@
+uuid: c2e100a6-4f15-4fab-8fdc-f390421bb76f
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_dawa_address
+    - node.type.junior_apprenticeship
+  module:
+    - dawa
+id: node.junior_apprenticeship.field_dawa_address
+field_name: field_dawa_address
+entity_type: node
+bundle: junior_apprenticeship
+label: Adresse
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: dawa_address_autocomplete

--- a/config/sync/field.field.node.junior_apprenticeship.field_desc_application_procedure.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_desc_application_procedure.yml
@@ -1,0 +1,29 @@
+uuid: 470895da-c257-4843-a0f3-2706b954d4b3
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_desc_application_procedure
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_desc_application_procedure
+field_name: field_desc_application_procedure
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Beskrivelse af ansøgningsprocedure'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_description_of_period.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_description_of_period.yml
@@ -1,0 +1,29 @@
+uuid: 1671986f-87f8-47a5-88d0-3bfdd6ddee92
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_description_of_period
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_description_of_period
+field_name: field_description_of_period
+entity_type: node
+bundle: junior_apprenticeship
+label: Periode
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_domain_access.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_domain_access.yml
@@ -1,0 +1,25 @@
+uuid: b45c6804-40a2-4a26-b3e5-4e6e331e989b
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_domain_access
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_domain_access
+field_name: field_domain_access
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Domain Access'
+description: 'Select the affiliate domain(s) for this content'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: 'Drupal\domain_access\DomainAccessManager::getDefaultValue'
+settings:
+  handler: 'default:domain'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: weight
+      direction: ASC
+field_type: entity_reference

--- a/config/sync/field.field.node.junior_apprenticeship.field_domain_all_affiliates.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_domain_all_affiliates.yml
@@ -1,0 +1,21 @@
+uuid: 730f7617-8e64-4fe6-8044-9018341e9502
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_domain_all_affiliates
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_domain_all_affiliates
+field_name: field_domain_all_affiliates
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Send to all affiliates'
+description: 'Make this content available on all domains.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: Tilsluttet
+  off_label: Afbrudt
+field_type: boolean

--- a/config/sync/field.field.node.junior_apprenticeship.field_duration_rte.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_duration_rte.yml
@@ -1,0 +1,29 @@
+uuid: 6fa50e48-261f-47c0-8bde-39b07b27a629
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_duration_rte
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_duration_rte
+field_name: field_duration_rte
+entity_type: node
+bundle: junior_apprenticeship
+label: Varighed
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_education_path.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_education_path.yml
@@ -1,0 +1,29 @@
+uuid: e9f01b27-7d93-42c0-849f-14de4a653c8a
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_education_path
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_education_path
+field_name: field_education_path
+entity_type: node
+bundle: junior_apprenticeship
+label: Uddannelsesvej
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_exclude_from_profile.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_exclude_from_profile.yml
@@ -1,0 +1,21 @@
+uuid: dcfc8fd4-0956-47bb-83b5-47dc2160bc58
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_from_profile
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_exclude_from_profile
+field_name: field_exclude_from_profile
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Vis ikke på profil'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: Tilsluttet
+  off_label: Afbrudt
+field_type: boolean

--- a/config/sync/field.field.node.junior_apprenticeship.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_exclude_from_search.yml
@@ -1,0 +1,21 @@
+uuid: 4b6337d3-a7f7-444f-8cf8-78bfeba6b6cf
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_from_search
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_exclude_from_search
+field_name: field_exclude_from_search
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Vis ikke i intern søgning'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: Tilsluttet
+  off_label: Afbrudt
+field_type: boolean

--- a/config/sync/field.field.node.junior_apprenticeship.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_exclude_from_search.yml
@@ -9,7 +9,7 @@ id: node.junior_apprenticeship.field_exclude_from_search
 field_name: field_exclude_from_search
 entity_type: node
 bundle: junior_apprenticeship
-label: 'Vis ikke i intern søgning'
+label: 'Vis ikke i søgning'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.junior_apprenticeship.field_expectations.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_expectations.yml
@@ -1,0 +1,29 @@
+uuid: 49104a13-f354-431b-8f7a-edb32e12f4c9
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_expectations
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_expectations
+field_name: field_expectations
+entity_type: node
+bundle: junior_apprenticeship
+label: Forventninger
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_hide_contact_form.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_hide_contact_form.yml
@@ -1,0 +1,21 @@
+uuid: 04efd9f3-e1e9-4e39-b3f7-951ce3357c59
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_contact_form
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_hide_contact_form
+field_name: field_hide_contact_form
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Skjul kontaktformular'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: Tilsluttet
+  off_label: Afbrudt
+field_type: boolean

--- a/config/sync/field.field.node.junior_apprenticeship.field_image.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_image.yml
@@ -1,0 +1,38 @@
+uuid: fb282322-2132-4840-8adb-42ff5ab06205
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - node.type.junior_apprenticeship
+  module:
+    - image
+id: node.junior_apprenticeship.field_image
+field_name: field_image
+entity_type: node
+bundle: junior_apprenticeship
+label: Billede
+description: 'OBS! Det er udbyders ansvar at sikre, at der er styr på rettigheder og tilladelser, når I uploader billeder.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg webp'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: 1584x700
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.field.node.junior_apprenticeship.field_industry.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_industry.yml
@@ -1,0 +1,29 @@
+uuid: 962304b3-9069-4270-beb3-4c76de48d89d
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_industry
+    - node.type.junior_apprenticeship
+    - taxonomy.vocabulary.industries
+id: node.junior_apprenticeship.field_industry
+field_name: field_industry
+entity_type: node
+bundle: junior_apprenticeship
+label: Branche
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      industries: industries
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.junior_apprenticeship.field_location_description.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_location_description.yml
@@ -1,0 +1,29 @@
+uuid: 6a7e25fa-ad0e-4fd3-b65d-a88713ea8572
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_location_description
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_location_description
+field_name: field_location_description
+entity_type: node
+bundle: junior_apprenticeship
+label: Sted
+description: "Eks. 'Store Sal', 'Brug højre indgang - ring på dørklokken' "
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_location_name.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_location_name.yml
@@ -1,0 +1,19 @@
+uuid: c177cf8d-939e-432f-b920-0823ae3179ff
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_location_name
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_location_name
+field_name: field_location_name
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Navn på lokalitet'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_materials.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_materials.yml
@@ -1,0 +1,61 @@
+uuid: db7be257-f7a4-42d7-a303-7ef79dcf7ca3
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_materials
+    - node.type.junior_apprenticeship
+    - paragraphs.paragraphs_type.material
+  module:
+    - entity_reference_revisions
+id: node.junior_apprenticeship.field_materials
+field_name: field_materials
+entity_type: node
+bundle: junior_apprenticeship
+label: Materialer
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      material: material
+    negate: 0
+    target_bundles_drag_drop:
+      accordion_item:
+        weight: 5
+        enabled: false
+      allocated_budget:
+        weight: 13
+        enabled: false
+      basic_hero:
+        weight: 6
+        enabled: false
+      cards:
+        weight: 15
+        enabled: false
+      contact_paragraph:
+        weight: 16
+        enabled: false
+      duration_paragraph:
+        weight: 17
+        enabled: false
+      duration_price:
+        weight: 18
+        enabled: false
+      inline_hero:
+        weight: 7
+        enabled: false
+      material:
+        weight: 8
+        enabled: true
+      other_user_info:
+        weight: 21
+        enabled: false
+      video:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.junior_apprenticeship.field_meeting_times.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_meeting_times.yml
@@ -1,0 +1,29 @@
+uuid: 85f48119-c8c5-4033-bd8e-33bfe96ae5dd
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meeting_times
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_meeting_times
+field_name: field_meeting_times
+entity_type: node
+bundle: junior_apprenticeship
+label: Mødetider
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_meta_tags.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_meta_tags.yml
@@ -1,0 +1,21 @@
+uuid: 429f726d-6c07-46aa-84fe-574ed780cf08
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.junior_apprenticeship
+  module:
+    - metatag
+id: node.junior_apprenticeship.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: junior_apprenticeship
+label: Meta-tags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/sync/field.field.node.junior_apprenticeship.field_open_for_application.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_open_for_application.yml
@@ -1,0 +1,23 @@
+uuid: acfccaf5-3613-4a94-b972-d6fb03eb91e1
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_open_for_application
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_open_for_application
+field_name: field_open_for_application
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Åben for ansøgning'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'Vi har åben for ansøgning'
+  off_label: 'Vi har desværre ikke åben for ansøgnin'
+field_type: boolean

--- a/config/sync/field.field.node.junior_apprenticeship.field_p_number.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_p_number.yml
@@ -1,0 +1,19 @@
+uuid: 6ac65d26-dff7-49a2-8913-85b967542bd4
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_p_number
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_p_number
+field_name: field_p_number
+entity_type: node
+bundle: junior_apprenticeship
+label: P-nummer
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_pretix_email_notifiers.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_pretix_email_notifiers.yml
@@ -1,0 +1,19 @@
+uuid: a0af9239-71bd-4aa3-b23c-24decbce5e01
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pretix_email_notifiers
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_pretix_email_notifiers
+field_name: field_pretix_email_notifiers
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Pretix email notifiers'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/sync/field.field.node.junior_apprenticeship.field_pretix_event_short_form.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_pretix_event_short_form.yml
@@ -1,0 +1,19 @@
+uuid: 96da5460-679f-4d05-8003-02f8ccbe0a5e
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pretix_event_short_form
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_pretix_event_short_form
+field_name: field_pretix_event_short_form
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Pretix event short form'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_pretix_shop_url.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_pretix_shop_url.yml
@@ -1,0 +1,23 @@
+uuid: 9b0d0ed4-d099-495c-b194-8487ca4e74a7
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pretix_shop_url
+    - node.type.junior_apprenticeship
+  module:
+    - link
+id: node.junior_apprenticeship.field_pretix_shop_url
+field_name: field_pretix_shop_url
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Pretix shop URL'
+description: 'Efterlad tom for a bruge Pretix integrationen istedet.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/sync/field.field.node.junior_apprenticeship.field_pretix_template_event.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_pretix_template_event.yml
@@ -1,0 +1,19 @@
+uuid: d8b0ce4d-e800-44a4-93c4-44aa1bd6f069
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pretix_template_event
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_pretix_template_event
+field_name: field_pretix_template_event
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Pretix template event'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_pretix_widget_type.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_pretix_widget_type.yml
@@ -1,0 +1,23 @@
+uuid: 3e387a18-ad12-4251-92d0-55276baac463
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pretix_widget_type
+    - node.type.junior_apprenticeship
+  module:
+    - options
+id: node.junior_apprenticeship.field_pretix_widget_type
+field_name: field_pretix_widget_type
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Pretix widget type'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: list
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.junior_apprenticeship.field_purpose_internship.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_purpose_internship.yml
@@ -1,0 +1,29 @@
+uuid: 4afeb765-a025-49c9-87e0-b70f517bd937
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_purpose_internship
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_purpose_internship
+field_name: field_purpose_internship
+entity_type: node
+bundle: junior_apprenticeship
+label: Formål
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_quantity.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_quantity.yml
@@ -1,0 +1,19 @@
+uuid: 365c3ee4-bbc6-4cbc-a797-0dc2162acc08
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_quantity
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_quantity
+field_name: field_quantity
+entity_type: node
+bundle: junior_apprenticeship
+label: Antal
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_related_courses.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_related_courses.yml
@@ -1,0 +1,26 @@
+uuid: e1dd43a3-96cc-4206-b6f6-6961a24f268f
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_related_courses
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_related_courses
+field_name: field_related_courses
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Relaterede forløb'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: views
+  handler_settings:
+    view:
+      view_name: content_entity_reference
+      display_name: entity_reference_1
+      arguments:
+        - internship+course_educators+course
+field_type: entity_reference

--- a/config/sync/field.field.node.junior_apprenticeship.field_show_application_link.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_show_application_link.yml
@@ -1,0 +1,21 @@
+uuid: 022b4add-7390-43a8-9e3c-8cae618b5726
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_show_application_link
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_show_application_link
+field_name: field_show_application_link
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Vis ansøgningslink'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: Vis
+  off_label: 'Vis ikke'
+field_type: boolean

--- a/config/sync/field.field.node.junior_apprenticeship.field_todo_list.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_todo_list.yml
@@ -1,0 +1,29 @@
+uuid: 1364b80a-8e5d-4d64-a736-cb1f7f4d775e
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_todo_list
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats:
+      - basic_html
+id: node.junior_apprenticeship.field_todo_list
+field_name: field_todo_list
+entity_type: node
+bundle: junior_apprenticeship
+label: Huskeliste
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_video.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_video.yml
@@ -1,0 +1,61 @@
+uuid: 4cb8561b-1a29-40f8-9ca2-5651abc73482
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_video
+    - node.type.junior_apprenticeship
+    - paragraphs.paragraphs_type.video
+  module:
+    - entity_reference_revisions
+id: node.junior_apprenticeship.field_video
+field_name: field_video
+entity_type: node
+bundle: junior_apprenticeship
+label: Video
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      video: video
+    negate: 0
+    target_bundles_drag_drop:
+      accordion_item:
+        weight: 9
+        enabled: false
+      allocated_budget:
+        weight: 13
+        enabled: false
+      basic_hero:
+        weight: 10
+        enabled: false
+      cards:
+        weight: 15
+        enabled: false
+      contact_paragraph:
+        weight: 11
+        enabled: false
+      duration_paragraph:
+        weight: 12
+        enabled: false
+      duration_price:
+        weight: 13
+        enabled: false
+      inline_hero:
+        weight: 14
+        enabled: false
+      material:
+        weight: 15
+        enabled: false
+      other_user_info:
+        weight: 21
+        enabled: false
+      video:
+        weight: 16
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.junior_apprenticeship.field_video_description.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_video_description.yml
@@ -1,0 +1,28 @@
+uuid: 8b003e29-2d92-4d6a-9f28-09771165b054
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_video_description
+    - filter.format.basic_html
+    - node.type.junior_apprenticeship
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.junior_apprenticeship.field_video_description
+field_name: field_video_description
+entity_type: node
+bundle: junior_apprenticeship
+label: Beskrivelse
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - basic_html
+field_type: text_long

--- a/config/sync/field.field.node.junior_apprenticeship.field_video_title.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_video_title.yml
@@ -1,0 +1,19 @@
+uuid: 1c7c1288-2f63-436e-952f-6b678c05c0b3
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_video_title
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship.field_video_title
+field_name: field_video_title
+entity_type: node
+bundle: junior_apprenticeship
+label: Overskrift
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.junior_apprenticeship.field_view_on_map.yml
+++ b/config/sync/field.field.node.junior_apprenticeship.field_view_on_map.yml
@@ -1,0 +1,23 @@
+uuid: 208db0f1-8885-4f47-9ecd-72ddd820f2b9
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_view_on_map
+    - node.type.junior_apprenticeship
+  module:
+    - options
+id: node.junior_apprenticeship.field_view_on_map
+field_name: field_view_on_map
+entity_type: node
+bundle: junior_apprenticeship
+label: 'Visning på kort'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: show_vendor_address
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.news.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.news.field_exclude_from_search.yml
@@ -9,7 +9,7 @@ id: node.news.field_exclude_from_search
 field_name: field_exclude_from_search
 entity_type: node
 bundle: news
-label: 'Vis ikke i intern søgning'
+label: 'Vis ikke i søgning'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.page.field_exclude_from_search.yml
+++ b/config/sync/field.field.node.page.field_exclude_from_search.yml
@@ -9,7 +9,7 @@ id: node.page.field_exclude_from_search
 field_name: field_exclude_from_search
 entity_type: node
 bundle: page
-label: 'Vis ikke i intern søgning'
+label: 'Vis ikke i søgning'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.transport_pool_form.field_rfc_name.yml
+++ b/config/sync/field.field.node.transport_pool_form.field_rfc_name.yml
@@ -9,7 +9,7 @@ id: node.transport_pool_form.field_rfc_name
 field_name: field_rfc_name
 entity_type: node
 bundle: transport_pool_form
-label: Navn
+label: 'Navn på medfølgende voksen'
 description: ''
 required: true
 translatable: false

--- a/config/sync/field.field.node.transport_pool_form.field_rfc_phone.yml
+++ b/config/sync/field.field.node.transport_pool_form.field_rfc_phone.yml
@@ -9,7 +9,7 @@ id: node.transport_pool_form.field_rfc_phone
 field_name: field_rfc_phone
 entity_type: node
 bundle: transport_pool_form
-label: Telefonnr
+label: 'Telefonnummer på medfølgende voksen'
 description: ''
 required: true
 translatable: false

--- a/config/sync/field.storage.node.field_open_for_application.yml
+++ b/config/sync/field.storage.node.field_open_for_application.yml
@@ -1,0 +1,18 @@
+uuid: 022b397a-8636-4d15-bff8-3630161da333
+langcode: da
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_open_for_application
+field_name: field_open_for_application
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_view_on_map.yml
+++ b/config/sync/field.storage.node.field_view_on_map.yml
@@ -19,7 +19,7 @@ settings:
       label: 'Vis alternativ adresse'
     -
       value: hidden_on_map
-      label: 'Vis ikke på kort'
+      label: 'Ingen adresse/Vis ikke på kort'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/sync/field.storage.user.field_view_on_map.yml
+++ b/config/sync/field.storage.user.field_view_on_map.yml
@@ -16,7 +16,7 @@ settings:
       label: 'Vis på kort'
     -
       value: hidden_on_map
-      label: 'Vis ikke på kort'
+      label: 'Ingen adresse/Vis ikke på kort'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/sync/language.content_settings.node.junior_apprenticeship.yml
+++ b/config/sync/language.content_settings.node.junior_apprenticeship.yml
@@ -1,0 +1,11 @@
+uuid: 3f52bb60-1184-42d1-85ac-c83a463b2d54
+langcode: da
+status: true
+dependencies:
+  config:
+    - node.type.junior_apprenticeship
+id: node.junior_apprenticeship
+target_entity_type_id: node
+target_bundle: junior_apprenticeship
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/node.type.junior_apprenticeship.yml
+++ b/config/sync/node.type.junior_apprenticeship.yml
@@ -1,0 +1,18 @@
+uuid: 1f81a6cf-a928-466d-808e-b46c9710eff1
+langcode: da
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Juniormesterlære
+type: junior_apprenticeship
+description: null
+help: null
+new_revision: true
+preview_mode: 0
+display_submitted: true

--- a/config/sync/search_api.index.content.yml
+++ b/config/sync/search_api.index.content.yml
@@ -10,6 +10,7 @@ dependencies:
     - layoutbuilder_search_api
     - node
     - os2uol_search
+    - search_api_exclude_entity
     - search_api_solr
     - user
 third_party_settings:
@@ -257,6 +258,7 @@ processor_settings:
       basic: basic
       quote: quote
       rte: rte
+      application_form: 0
       button: 0
       code: 0
       divider: 0
@@ -264,6 +266,7 @@ processor_settings:
       footer: 0
       hero: 0
       image: 0
+      image_with_link: 0
       inline_navigation: 0
       inspiration: 0
       slideshow: 0
@@ -271,6 +274,9 @@ processor_settings:
       video: 0
   post_number_city: {  }
   rendered_item: {  }
+  search_api_exclude_entity_processor:
+    fields:
+      node: {  }
   solr_date_range:
     weights:
       preprocess_index: 0

--- a/config/sync/search_api.index.search.yml
+++ b/config/sync/search_api.index.search.yml
@@ -49,6 +49,7 @@ dependencies:
     - layoutbuilder_search_api
     - node
     - os2uol_search
+    - search_api_exclude_entity
     - search_api_solr
     - taxonomy
     - user
@@ -304,7 +305,7 @@ field_settings:
       module:
         - taxonomy
   field_exclude_from_search:
-    label: 'Vis ikke i intern søgning'
+    label: 'Vis ikke i søgning'
     datasource_id: 'entity:node'
     property_path: field_exclude_from_search
     type: boolean
@@ -757,6 +758,7 @@ processor_settings:
       basic: basic
       quote: quote
       rte: rte
+      application_form: 0
       button: 0
       code: 0
       divider: 0
@@ -764,6 +766,7 @@ processor_settings:
       footer: 0
       hero: 0
       image: 0
+      image_with_link: 0
       inline_navigation: 0
       inspiration: 0
       slideshow: 0
@@ -771,6 +774,10 @@ processor_settings:
       video: 0
   post_number_city: {  }
   rendered_item: {  }
+  search_api_exclude_entity_processor:
+    fields:
+      node: {  }
+      user: {  }
   solr_date_range:
     weights:
       preprocess_index: 0

--- a/config/sync/search_api.index.search.yml
+++ b/config/sync/search_api.index.search.yml
@@ -3,55 +3,55 @@ langcode: da
 status: true
 dependencies:
   config:
-    - field.storage.node.field_activity_select
-    - field.storage.node.field_activities
     - field.storage.node.body
-    - field.storage.node.field_description
-    - field.storage.node.field_sustainability_goals_desc
-    - field.storage.node.field_related_user
-    - field.storage.user.field_name
-    - field.storage.node.field_industry
-    - field.storage.node.field_post_processing
-    - field.storage.node.field_subject
-    - field.storage.node.field_primary_school_subject
-    - field.storage.node.field_youth_education_subject
-    - field.storage.node.field_focus
-    - field.storage.node.field_preparation
-    - field.storage.node.field_course_type
-    - field.storage.node.field_purpose
-    - field.storage.node.field_expectations
     - field.storage.node.field_ackground_knowledge
-    - field.storage.node.field_is_free
+    - field.storage.node.field_activities
+    - field.storage.node.field_activity_select
     - field.storage.node.field_all_year
     - field.storage.node.field_areas_of_interest
+    - field.storage.node.field_course_type
     - field.storage.node.field_curriculum_themes
-    - field.storage.node.field_purpose_exercise
+    - field.storage.node.field_description
+    - field.storage.node.field_duration_select
     - field.storage.node.field_educators_target_group
+    - field.storage.node.field_exclude_from_search
+    - field.storage.node.field_expectations
+    - field.storage.node.field_focus
+    - field.storage.node.field_how_to
+    - field.storage.node.field_industry
+    - field.storage.node.field_is_free
+    - field.storage.node.field_open_for_application
+    - field.storage.node.field_period
+    - field.storage.node.field_period_select
+    - field.storage.node.field_post_processing
+    - field.storage.node.field_preparation
+    - field.storage.node.field_primary_school_subject
+    - field.storage.node.field_purpose
+    - field.storage.node.field_purpose_exercise
+    - field.storage.node.field_related_user
+    - field.storage.node.field_subject
+    - field.storage.node.field_sustainability_goals
+    - field.storage.node.field_sustainability_goals_desc
+    - field.storage.node.field_target_group
+    - field.storage.node.field_theme
     - field.storage.node.field_trgt_grp_daycare
     - field.storage.node.field_trgt_grp_primary_school
     - field.storage.node.field_trgt_grp_youth_education
-    - field.storage.node.field_target_group
-    - field.storage.node.field_period
-    - field.storage.node.field_period_select
-    - field.storage.node.field_how_to
-    - field.storage.node.field_theme
-    - field.storage.user.field_guarantee_partner
-    - field.storage.node.field_duration_select
-    - field.storage.node.field_sustainability_goals
-    - field.storage.node.field_exclude_from_search
+    - field.storage.node.field_youth_education_subject
     - field.storage.user.field_brancher
+    - field.storage.user.field_guarantee_partner
+    - field.storage.user.field_name
     - field.storage.user.field_posibilities
     - field.storage.user.field_postnummer
     - field.storage.user.field_presentation
     - search_api.server.solr
   module:
+    - layoutbuilder_search_api
+    - node
+    - os2uol_search
     - search_api_solr
     - taxonomy
     - user
-    - node
-    - search_api
-    - layoutbuilder_search_api
-    - os2uol_search
 third_party_settings:
   search_api_solr:
     finalize: false
@@ -378,6 +378,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.user.field_name
+  field_open_for_application:
+    label: 'Åben for ansøgning'
+    datasource_id: 'entity:node'
+    property_path: field_open_for_application
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.node.field_open_for_application
   field_period:
     label: Periode
     datasource_id: 'entity:node'
@@ -725,6 +733,7 @@ datasource_settings:
         - course_educators
         - exercise
         - internship
+        - junior_apprenticeship
         - news
         - page
     languages:
@@ -770,6 +779,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: solr

--- a/config/sync/simple_sitemap.sitemap.api_udoglaer_roskilde_dk.yml
+++ b/config/sync/simple_sitemap.sitemap.api_udoglaer_roskilde_dk.yml
@@ -1,0 +1,11 @@
+uuid: ea190ace-e9bb-4b0d-8ba6-4a457e54e988
+langcode: da
+status: true
+dependencies:
+  config:
+    - simple_sitemap.type.api_udoglaer_roskilde_dk
+id: api_udoglaer_roskilde_dk
+label: 'udoglaer.roskilde.dk sitemap'
+description: 'Sitemap variant for domain: udoglaer.roskilde.dk'
+type: api_udoglaer_roskilde_dk
+weight: 0

--- a/config/sync/simple_sitemap.type.api_udoglaer_roskilde_dk.yml
+++ b/config/sync/simple_sitemap.type.api_udoglaer_roskilde_dk.yml
@@ -1,0 +1,18 @@
+uuid: 59a3d4d4-59bc-4491-9fe5-a4b74e5d7621
+langcode: da
+status: true
+dependencies:
+  module:
+    - domain_simple_sitemap
+third_party_settings:
+  domain_simple_sitemap:
+    sitemap_domain: api_udoglaer_roskilde_dk
+id: api_udoglaer_roskilde_dk
+label: 'udoglaer.roskilde.dk sitemap'
+description: 'Sitemap type for domain: udoglaer.roskilde.dk'
+sitemap_generator: default
+url_generators:
+  - domain_entity
+  - custom
+  - entity_menu_link_content
+  - arbitrary

--- a/config/sync/system.action.domain_access_add_action.api_udoglaer_roskilde_dk.yml
+++ b/config/sync/system.action.domain_access_add_action.api_udoglaer_roskilde_dk.yml
@@ -1,0 +1,14 @@
+uuid: 61f64d57-0b56-44e5-9781-7235cb628c69
+langcode: da
+status: true
+dependencies:
+  config:
+    - domain.record.api_udoglaer_roskilde_dk
+  module:
+    - domain_access
+id: domain_access_add_action.api_udoglaer_roskilde_dk
+label: 'Add selected content to the udoglaer.roskilde.dk domain'
+type: node
+plugin: domain_access_add_action
+configuration:
+  domain_id: api_udoglaer_roskilde_dk

--- a/config/sync/system.action.domain_access_add_editor_action.api_udoglaer_roskilde_dk.yml
+++ b/config/sync/system.action.domain_access_add_editor_action.api_udoglaer_roskilde_dk.yml
@@ -1,0 +1,14 @@
+uuid: ecb4da35-9b48-4f72-a131-c550c1f2de08
+langcode: da
+status: true
+dependencies:
+  config:
+    - domain.record.api_udoglaer_roskilde_dk
+  module:
+    - domain_access
+id: domain_access_add_editor_action.api_udoglaer_roskilde_dk
+label: 'Add editors to the udoglaer.roskilde.dk domain'
+type: user
+plugin: domain_access_add_editor_action
+configuration:
+  domain_id: api_udoglaer_roskilde_dk

--- a/config/sync/system.action.domain_access_remove_action.api_udoglaer_roskilde_dk.yml
+++ b/config/sync/system.action.domain_access_remove_action.api_udoglaer_roskilde_dk.yml
@@ -1,0 +1,14 @@
+uuid: 3fe4cbf4-e56f-45e2-815b-89e418b0a3b4
+langcode: da
+status: true
+dependencies:
+  config:
+    - domain.record.api_udoglaer_roskilde_dk
+  module:
+    - domain_access
+id: domain_access_remove_action.api_udoglaer_roskilde_dk
+label: 'Remove selected content from the udoglaer.roskilde.dk domain'
+type: node
+plugin: domain_access_remove_action
+configuration:
+  domain_id: api_udoglaer_roskilde_dk

--- a/config/sync/system.action.domain_access_remove_editor_action.api_udoglaer_roskilde_dk.yml
+++ b/config/sync/system.action.domain_access_remove_editor_action.api_udoglaer_roskilde_dk.yml
@@ -1,0 +1,14 @@
+uuid: 89d088a5-21d9-4064-b967-e00ee53f9b3a
+langcode: da
+status: true
+dependencies:
+  config:
+    - domain.record.api_udoglaer_roskilde_dk
+  module:
+    - domain_access
+id: domain_access_remove_editor_action.api_udoglaer_roskilde_dk
+label: 'Remove editors from the udoglaer.roskilde.dk domain'
+type: user
+plugin: domain_access_remove_editor_action
+configuration:
+  domain_id: api_udoglaer_roskilde_dk

--- a/config/sync/system.menu.dm4157052-main.yml
+++ b/config/sync/system.menu.dm4157052-main.yml
@@ -1,0 +1,15 @@
+uuid: 8399bdc7-0c48-40b7-acac-b77f993eee59
+langcode: da
+status: true
+dependencies:
+  module:
+    - domain_menus
+third_party_settings:
+  domain_menus:
+    domains:
+      api_udoglaer_roskilde_dk: api_udoglaer_roskilde_dk
+    auto-created: 1
+id: dm4157052-main
+label: 'Domain menu for udoglaer.roskilde.dk (main)'
+description: null
+locked: false

--- a/config/sync/system.menu.dm4157052-meta.yml
+++ b/config/sync/system.menu.dm4157052-meta.yml
@@ -1,0 +1,15 @@
+uuid: e544086e-eb7c-4b59-8f66-f70aa3a2edc1
+langcode: da
+status: true
+dependencies:
+  module:
+    - domain_menus
+third_party_settings:
+  domain_menus:
+    domains:
+      api_udoglaer_roskilde_dk: api_udoglaer_roskilde_dk
+    auto-created: 1
+id: dm4157052-meta
+label: 'Domain menu for udoglaer.roskilde.dk (meta)'
+description: null
+locked: false

--- a/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.default.yml
+++ b/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.default.yml
@@ -1,0 +1,283 @@
+uuid: b085bc4e-b8f5-4f3b-a645-c6be5991cd2c
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - node.type.junior_apprenticeship
+    - responsive_image.styles.isg_course_header
+  module:
+    - transform_api_responsive_image
+id: node.junior_apprenticeship.default
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: default
+content:
+  body:
+    type: text_format
+    weight: '1'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_deadline:
+    type: datetime_default
+    weight: '11'
+    region: content
+    label: omit
+    settings:
+      timezone_override: ''
+      format_type: os2date
+    third_party_settings: {  }
+  field_application_email:
+    type: value
+    weight: '14'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_phone:
+    type: value
+    weight: '15'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_title:
+    type: value
+    weight: '12'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_url:
+    type: value
+    weight: '13'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_areas_of_interest:
+    type: entity_reference_labels
+    weight: '6'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_banner:
+    type: entity_reference_labels
+    weight: '3'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_desc_application_procedure:
+    type: text_format
+    weight: '20'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_description_of_period:
+    type: text_format
+    weight: '19'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_duration_rte:
+    type: text_format
+    weight: '21'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_education_path:
+    type: text_format
+    weight: '22'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_expectations:
+    type: text_format
+    weight: '2'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: responsive_image
+    weight: '0'
+    region: content
+    label: omit
+    settings:
+      responsive_image_style: isg_course_header
+      image_link: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+  field_industry:
+    type: entity_reference_labels
+    weight: '7'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_location_description:
+    type: text_format
+    weight: '23'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_location_name:
+    type: value
+    weight: '17'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_materials:
+    type: entity_transform
+    weight: '10'
+    region: content
+    label: omit
+    settings:
+      transform_mode: materials
+    third_party_settings: {  }
+  field_meeting_times:
+    type: text_format
+    weight: '24'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_open_for_application:
+    type: boolean
+    weight: '28'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_purpose_internship:
+    type: text_format
+    weight: '18'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_quantity:
+    type: value
+    weight: '5'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_related_courses:
+    type: entity_transform
+    weight: '27'
+    region: content
+    label: omit
+    settings:
+      transform_mode: default
+    third_party_settings: {  }
+  field_show_application_link:
+    type: boolean
+    weight: '16'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_todo_list:
+    type: text_format
+    weight: '25'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_video:
+    type: entity_transform
+    weight: '26'
+    region: content
+    label: omit
+    settings:
+      transform_mode: default
+    third_party_settings: {  }
+  field_video_description:
+    type: text_format
+    weight: '9'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_video_title:
+    type: value
+    weight: '8'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_view_on_map:
+    type: value
+    weight: '4'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_dawa_address: true
+  field_domain_access: true
+  field_domain_all_affiliates: true
+  field_exclude_from_profile: true
+  field_exclude_from_search: true
+  field_hide_contact_form: true
+  field_meta_tags: true
+  field_p_number: true
+  field_pretix_email_notifiers: true
+  field_pretix_event_short_form: true
+  field_pretix_shop_url: true
+  field_pretix_template_event: true
+  field_pretix_widget_type: true
+  langcode: true

--- a/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.full.yml
+++ b/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.full.yml
@@ -1,0 +1,316 @@
+uuid: 0095bdfa-cad1-4dd5-9250-295ac393d726
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - node.type.junior_apprenticeship
+    - responsive_image.styles.isg_course_header
+    - transform_api.entity_transform_mode.node.full
+  module:
+    - transform_api_dawa
+    - transform_api_responsive_image
+id: node.junior_apprenticeship.full
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: full
+content:
+  body:
+    type: text_format
+    weight: '1'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_deadline:
+    type: datetime_default
+    weight: '11'
+    region: content
+    label: omit
+    settings:
+      timezone_override: ''
+      format_type: os2date
+    third_party_settings: {  }
+  field_application_email:
+    type: value
+    weight: '14'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_phone:
+    type: value
+    weight: '15'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_title:
+    type: value
+    weight: '12'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_application_url:
+    type: value
+    weight: '13'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_areas_of_interest:
+    type: entity_reference_labels
+    weight: '6'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_banner:
+    type: entity_reference_labels
+    weight: '3'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_dawa_address:
+    type: dawa_address_transform
+    weight: '32'
+    region: content
+    label: omit
+    settings:
+      transform_mode: all
+    third_party_settings: {  }
+  field_desc_application_procedure:
+    type: text_format
+    weight: '20'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_description_of_period:
+    type: text_format
+    weight: '19'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_duration_rte:
+    type: text_format
+    weight: '21'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_education_path:
+    type: text_format
+    weight: '22'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_expectations:
+    type: text_format
+    weight: '2'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_hide_contact_form:
+    type: boolean
+    weight: '28'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: responsive_image
+    weight: '0'
+    region: content
+    label: omit
+    settings:
+      responsive_image_style: isg_course_header
+      image_link: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+  field_industry:
+    type: entity_reference_labels
+    weight: '7'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_location_description:
+    type: text_format
+    weight: '23'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_location_name:
+    type: value
+    weight: '17'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_materials:
+    type: entity_transform
+    weight: '10'
+    region: content
+    label: omit
+    settings:
+      transform_mode: materials
+    third_party_settings: {  }
+  field_meeting_times:
+    type: text_format
+    weight: '24'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_meta_tags:
+    type: metatag
+    weight: '30'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_open_for_application:
+    type: boolean
+    weight: '33'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_p_number:
+    type: value
+    weight: '31'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_pretix_widget_type:
+    type: value
+    weight: '29'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_purpose_internship:
+    type: text_format
+    weight: '18'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_quantity:
+    type: value
+    weight: '5'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_related_courses:
+    type: entity_transform
+    weight: '27'
+    region: content
+    label: omit
+    settings:
+      transform_mode: default
+    third_party_settings: {  }
+  field_show_application_link:
+    type: boolean
+    weight: '16'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_todo_list:
+    type: text_format
+    weight: '25'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_video:
+    type: entity_transform
+    weight: '26'
+    region: content
+    label: omit
+    settings:
+      transform_mode: default
+    third_party_settings: {  }
+  field_video_description:
+    type: text_format
+    weight: '9'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_video_title:
+    type: value
+    weight: '8'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_view_on_map:
+    type: value
+    weight: '4'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_domain_access: true
+  field_domain_all_affiliates: true
+  field_exclude_from_profile: true
+  field_exclude_from_search: true
+  field_pretix_email_notifiers: true
+  field_pretix_event_short_form: true
+  field_pretix_shop_url: true
+  field_pretix_template_event: true
+  langcode: true

--- a/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.related_courses.yml
+++ b/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.related_courses.yml
@@ -1,0 +1,148 @@
+uuid: 8d0e78c9-2444-45d9-9b51-f51d720b2b75
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - node.type.junior_apprenticeship
+    - responsive_image.styles.isg_related_courses
+    - transform_api.entity_transform_mode.node.related_courses
+  module:
+    - transform_api_responsive_image
+id: node.junior_apprenticeship.related_courses
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: related_courses
+content:
+  body:
+    type: text_summary_or_trimmed
+    weight: '2'
+    region: content
+    label: omit
+    settings:
+      trim_length: '200'
+    third_party_settings: {  }
+  field_areas_of_interest:
+    type: entity_reference_labels
+    weight: '3'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_banner:
+    type: entity_reference_labels
+    weight: '1'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: responsive_image
+    weight: '0'
+    region: content
+    label: omit
+    settings:
+      responsive_image_style: isg_related_courses
+      image_link: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+  field_industry:
+    type: entity_reference_labels
+    weight: '4'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_open_for_application:
+    type: boolean
+    weight: '6'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_view_on_map:
+    type: value
+    weight: '5'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_application_deadline: true
+  field_application_email: true
+  field_application_phone: true
+  field_application_title: true
+  field_application_url: true
+  field_dawa_address: true
+  field_desc_application_procedure: true
+  field_description_of_period: true
+  field_domain_access: true
+  field_domain_all_affiliates: true
+  field_duration_rte: true
+  field_education_path: true
+  field_exclude_from_profile: true
+  field_exclude_from_search: true
+  field_expectations: true
+  field_hide_contact_form: true
+  field_location_description: true
+  field_location_name: true
+  field_materials: true
+  field_meeting_times: true
+  field_meta_tags: true
+  field_p_number: true
+  field_pretix_email_notifiers: true
+  field_pretix_event_short_form: true
+  field_pretix_shop_url: true
+  field_pretix_template_event: true
+  field_pretix_widget_type: true
+  field_purpose_internship: true
+  field_quantity: true
+  field_related_courses: true
+  field_show_application_link: true
+  field_todo_list: true
+  field_video: true
+  field_video_description: true
+  field_video_title: true
+  langcode: true

--- a/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.search_result.yml
+++ b/config/sync/transform_api.entity_transform_display.node.junior_apprenticeship.search_result.yml
@@ -1,0 +1,147 @@
+uuid: 64f2617e-a141-4502-bd0e-4fe231742e8b
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.node.junior_apprenticeship.body
+    - field.field.node.junior_apprenticeship.field_application_deadline
+    - field.field.node.junior_apprenticeship.field_application_email
+    - field.field.node.junior_apprenticeship.field_application_phone
+    - field.field.node.junior_apprenticeship.field_application_title
+    - field.field.node.junior_apprenticeship.field_application_url
+    - field.field.node.junior_apprenticeship.field_areas_of_interest
+    - field.field.node.junior_apprenticeship.field_banner
+    - field.field.node.junior_apprenticeship.field_dawa_address
+    - field.field.node.junior_apprenticeship.field_desc_application_procedure
+    - field.field.node.junior_apprenticeship.field_description_of_period
+    - field.field.node.junior_apprenticeship.field_domain_access
+    - field.field.node.junior_apprenticeship.field_domain_all_affiliates
+    - field.field.node.junior_apprenticeship.field_duration_rte
+    - field.field.node.junior_apprenticeship.field_education_path
+    - field.field.node.junior_apprenticeship.field_exclude_from_profile
+    - field.field.node.junior_apprenticeship.field_exclude_from_search
+    - field.field.node.junior_apprenticeship.field_expectations
+    - field.field.node.junior_apprenticeship.field_hide_contact_form
+    - field.field.node.junior_apprenticeship.field_image
+    - field.field.node.junior_apprenticeship.field_industry
+    - field.field.node.junior_apprenticeship.field_location_description
+    - field.field.node.junior_apprenticeship.field_location_name
+    - field.field.node.junior_apprenticeship.field_materials
+    - field.field.node.junior_apprenticeship.field_meeting_times
+    - field.field.node.junior_apprenticeship.field_meta_tags
+    - field.field.node.junior_apprenticeship.field_open_for_application
+    - field.field.node.junior_apprenticeship.field_p_number
+    - field.field.node.junior_apprenticeship.field_pretix_email_notifiers
+    - field.field.node.junior_apprenticeship.field_pretix_event_short_form
+    - field.field.node.junior_apprenticeship.field_pretix_shop_url
+    - field.field.node.junior_apprenticeship.field_pretix_template_event
+    - field.field.node.junior_apprenticeship.field_pretix_widget_type
+    - field.field.node.junior_apprenticeship.field_purpose_internship
+    - field.field.node.junior_apprenticeship.field_quantity
+    - field.field.node.junior_apprenticeship.field_related_courses
+    - field.field.node.junior_apprenticeship.field_show_application_link
+    - field.field.node.junior_apprenticeship.field_todo_list
+    - field.field.node.junior_apprenticeship.field_video
+    - field.field.node.junior_apprenticeship.field_video_description
+    - field.field.node.junior_apprenticeship.field_video_title
+    - field.field.node.junior_apprenticeship.field_view_on_map
+    - node.type.junior_apprenticeship
+    - responsive_image.styles.isg_related_courses
+    - transform_api.entity_transform_mode.node.search_result
+  module:
+    - transform_api_responsive_image
+id: node.junior_apprenticeship.search_result
+targetEntityType: node
+bundle: junior_apprenticeship
+mode: search_result
+content:
+  body:
+    type: text_format
+    weight: '0'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_areas_of_interest:
+    type: entity_reference_labels
+    weight: '2'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_banner:
+    type: entity_reference_labels
+    weight: '4'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: responsive_image
+    weight: '1'
+    region: content
+    label: omit
+    settings:
+      responsive_image_style: isg_related_courses
+      image_link: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+  field_industry:
+    type: entity_reference_labels
+    weight: '3'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_open_for_application:
+    type: boolean
+    weight: '6'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+  field_view_on_map:
+    type: value
+    weight: '5'
+    region: content
+    label: omit
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_application_deadline: true
+  field_application_email: true
+  field_application_phone: true
+  field_application_title: true
+  field_application_url: true
+  field_dawa_address: true
+  field_desc_application_procedure: true
+  field_description_of_period: true
+  field_domain_access: true
+  field_domain_all_affiliates: true
+  field_duration_rte: true
+  field_education_path: true
+  field_exclude_from_profile: true
+  field_exclude_from_search: true
+  field_expectations: true
+  field_hide_contact_form: true
+  field_location_description: true
+  field_location_name: true
+  field_materials: true
+  field_meeting_times: true
+  field_meta_tags: true
+  field_p_number: true
+  field_pretix_email_notifiers: true
+  field_pretix_event_short_form: true
+  field_pretix_shop_url: true
+  field_pretix_template_event: true
+  field_pretix_widget_type: true
+  field_purpose_internship: true
+  field_quantity: true
+  field_related_courses: true
+  field_show_application_link: true
+  field_todo_list: true
+  field_video: true
+  field_video_description: true
+  field_video_title: true
+  langcode: true

--- a/config/sync/user.role.bypass_workflow.yml
+++ b/config/sync/user.role.bypass_workflow.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.course_educators
     - node.type.exercise
     - node.type.internship
+    - node.type.junior_apprenticeship
     - node.type.news
     - node.type.transport_pool_form
     - workflows.workflow.editorial
@@ -37,17 +38,20 @@ permissions:
   - 'create exercise content on assigned domains'
   - 'create internship content'
   - 'create internship content on assigned domains'
+  - 'create junior_apprenticeship content'
   - 'create news content'
   - 'create news content on assigned domains'
   - 'delete own course content'
   - 'delete own course_educators content'
   - 'delete own exercise content'
   - 'delete own internship content'
+  - 'delete own junior_apprenticeship content'
   - 'delete own news content'
   - 'edit own course content'
   - 'edit own course_educators content'
   - 'edit own exercise content'
   - 'edit own internship content'
+  - 'edit own junior_apprenticeship content'
   - 'edit own news content'
   - 'update course content on assigned domains'
   - 'update course_educators content on assigned domains'
@@ -70,6 +74,7 @@ permissions:
   - 'view course_educators revisions'
   - 'view exercise revisions'
   - 'view internship revisions'
+  - 'view junior_apprenticeship revisions'
   - 'view latest version'
   - 'view news revisions'
   - 'view own unpublished content'

--- a/config/sync/user.role.corporation.yml
+++ b/config/sync/user.role.corporation.yml
@@ -9,6 +9,7 @@ dependencies:
     - node.type.exercise
     - node.type.free_course_request
     - node.type.internship
+    - node.type.junior_apprenticeship
     - node.type.news
     - node.type.theater_refund
     - node.type.transport_pool_form
@@ -43,11 +44,13 @@ permissions:
   - 'create exercise content on assigned domains'
   - 'create internship content'
   - 'create internship content on assigned domains'
+  - 'create junior_apprenticeship content'
   - 'create news content'
   - 'delete own course content'
   - 'delete own course_educators content'
   - 'delete own exercise content'
   - 'delete own internship content'
+  - 'delete own junior_apprenticeship content'
   - 'delete own news content'
   - 'delete own transport_pool_form content'
   - 'delete pretix dates'
@@ -56,6 +59,7 @@ permissions:
   - 'edit own course_educators content'
   - 'edit own exercise content'
   - 'edit own internship content'
+  - 'edit own junior_apprenticeship content'
   - 'edit own news content'
   - 'edit own pretix events'
   - 'edit own transport_pool_form content'
@@ -89,6 +93,7 @@ permissions:
   - 'view exercise revisions'
   - 'view free_course_request revisions'
   - 'view internship revisions'
+  - 'view junior_apprenticeship revisions'
   - 'view latest version'
   - 'view news revisions'
   - 'view own pretix events'

--- a/config/sync/user.role.course_provider.yml
+++ b/config/sync/user.role.course_provider.yml
@@ -9,6 +9,7 @@ dependencies:
     - node.type.exercise
     - node.type.free_course_request
     - node.type.internship
+    - node.type.junior_apprenticeship
     - node.type.news
     - node.type.theater_refund
     - node.type.transport_pool_form
@@ -43,12 +44,14 @@ permissions:
   - 'create exercise content on assigned domains'
   - 'create internship content'
   - 'create internship content on assigned domains'
+  - 'create junior_apprenticeship content'
   - 'create news content'
   - 'create news content on assigned domains'
   - 'delete own course content'
   - 'delete own course_educators content'
   - 'delete own exercise content'
   - 'delete own internship content'
+  - 'delete own junior_apprenticeship content'
   - 'delete own news content'
   - 'delete own transport_pool_form content'
   - 'delete pretix dates'
@@ -57,6 +60,7 @@ permissions:
   - 'edit own course_educators content'
   - 'edit own exercise content'
   - 'edit own internship content'
+  - 'edit own junior_apprenticeship content'
   - 'edit own news content'
   - 'edit own pretix events'
   - 'edit own transport_pool_form content'
@@ -90,6 +94,7 @@ permissions:
   - 'view exercise revisions'
   - 'view free_course_request revisions'
   - 'view internship revisions'
+  - 'view junior_apprenticeship revisions'
   - 'view latest version'
   - 'view news revisions'
   - 'view own pretix events'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -27,6 +27,7 @@ dependencies:
     - node.type.exercise
     - node.type.free_course_request
     - node.type.internship
+    - node.type.junior_apprenticeship
     - node.type.news
     - node.type.page
     - node.type.theater_refund
@@ -178,6 +179,7 @@ permissions:
   - 'create inline_navigation block content'
   - 'create inspiration block content'
   - 'create internship content'
+  - 'create junior_apprenticeship content'
   - 'create news content'
   - 'create page content'
   - 'create quote block content'
@@ -204,6 +206,7 @@ permissions:
   - 'delete any inline_navigation block content'
   - 'delete any inspiration block content'
   - 'delete any internship content'
+  - 'delete any junior_apprenticeship content'
   - 'delete any news content'
   - 'delete any page content'
   - 'delete any quote block content'
@@ -218,12 +221,14 @@ permissions:
   - 'delete domain content'
   - 'delete exercise revisions'
   - 'delete internship revisions'
+  - 'delete junior_apprenticeship revisions'
   - 'delete news revisions'
   - 'delete own course content'
   - 'delete own course_educators content'
   - 'delete own exercise content'
   - 'delete own files'
   - 'delete own internship content'
+  - 'delete own junior_apprenticeship content'
   - 'delete own news content'
   - 'delete own page content'
   - 'delete own transport_pool_form content'
@@ -248,6 +253,7 @@ permissions:
   - 'edit any inline_navigation block content'
   - 'edit any inspiration block content'
   - 'edit any internship content'
+  - 'edit any junior_apprenticeship content'
   - 'edit any news content'
   - 'edit any page content'
   - 'edit any quote block content'
@@ -266,6 +272,7 @@ permissions:
   - 'edit own course_educators content'
   - 'edit own exercise content'
   - 'edit own internship content'
+  - 'edit own junior_apprenticeship content'
   - 'edit own news content'
   - 'edit own page content'
   - 'edit own pretix events'
@@ -281,6 +288,7 @@ permissions:
   - 'revert course_educators revisions'
   - 'revert exercise revisions'
   - 'revert internship revisions'
+  - 'revert junior_apprenticeship revisions'
   - 'revert news revisions'
   - 'revert page revisions'
   - 'select account cancellation method'
@@ -327,6 +335,7 @@ permissions:
   - 'view exercise revisions'
   - 'view free_course_request revisions'
   - 'view internship revisions'
+  - 'view junior_apprenticeship revisions'
   - 'view latest version'
   - 'view news revisions'
   - 'view own pretix events'

--- a/config/sync/user.role.webmaster.yml
+++ b/config/sync/user.role.webmaster.yml
@@ -28,6 +28,7 @@ dependencies:
     - node.type.exercise
     - node.type.free_course_request
     - node.type.internship
+    - node.type.junior_apprenticeship
     - node.type.news
     - node.type.page
     - node.type.theater_refund
@@ -221,6 +222,7 @@ permissions:
   - 'create inline_navigation block content'
   - 'create inspiration block content'
   - 'create internship content'
+  - 'create junior_apprenticeship content'
   - 'create news content'
   - 'create page content'
   - 'create quote block content'
@@ -270,6 +272,7 @@ permissions:
   - 'delete any inline_navigation block content'
   - 'delete any inspiration block content'
   - 'delete any internship content'
+  - 'delete any junior_apprenticeship content'
   - 'delete any news content'
   - 'delete any page content'
   - 'delete any quote block content'
@@ -285,12 +288,14 @@ permissions:
   - 'delete domain content'
   - 'delete exercise revisions'
   - 'delete internship revisions'
+  - 'delete junior_apprenticeship revisions'
   - 'delete news revisions'
   - 'delete own course content'
   - 'delete own course_educators content'
   - 'delete own exercise content'
   - 'delete own files'
   - 'delete own internship content'
+  - 'delete own junior_apprenticeship content'
   - 'delete own news content'
   - 'delete own page content'
   - 'delete own transport_pool_form content'
@@ -336,6 +341,7 @@ permissions:
   - 'edit any inline_navigation block content'
   - 'edit any inspiration block content'
   - 'edit any internship content'
+  - 'edit any junior_apprenticeship content'
   - 'edit any news content'
   - 'edit any page content'
   - 'edit any quote block content'
@@ -354,6 +360,7 @@ permissions:
   - 'edit own course_educators content'
   - 'edit own exercise content'
   - 'edit own internship content'
+  - 'edit own junior_apprenticeship content'
   - 'edit own news content'
   - 'edit own page content'
   - 'edit own pretix events'
@@ -390,6 +397,7 @@ permissions:
   - 'revert course_educators revisions'
   - 'revert exercise revisions'
   - 'revert internship revisions'
+  - 'revert junior_apprenticeship revisions'
   - 'revert news revisions'
   - 'revert page revisions'
   - 'select account cancellation method'
@@ -442,6 +450,7 @@ permissions:
   - 'view free_course_request revisions'
   - 'view free_course_request revisions'
   - 'view internship revisions'
+  - 'view junior_apprenticeship revisions'
   - 'view latest version'
   - 'view news revisions'
   - 'view own pretix events'

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -766,10 +766,11 @@ display:
           operator: in
           value:
             internship: internship
+            page: page
+            junior_apprenticeship: junior_apprenticeship
             course_educators: course_educators
             news: news
             exercise: exercise
-            page: page
             course: course
           group: 1
           exposed: true
@@ -1447,10 +1448,11 @@ display:
           operator: in
           value:
             internship: internship
+            page: page
+            junior_apprenticeship: junior_apprenticeship
             course_educators: course_educators
             news: news
             exercise: exercise
-            page: page
             course: course
           group: 1
           exposed: true

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.course_educators
     - node.type.exercise
     - node.type.internship
+    - node.type.junior_apprenticeship
     - node.type.news
     - node.type.page
     - user.role.administrator
@@ -923,10 +924,11 @@ display:
           operator: in
           value:
             internship: internship
+            page: page
+            junior_apprenticeship: junior_apprenticeship
             course_educators: course_educators
             news: news
             exercise: exercise
-            page: page
             course: course
           group: 1
           exposed: false
@@ -1615,10 +1617,11 @@ display:
           operator: in
           value:
             internship: internship
+            page: page
+            junior_apprenticeship: junior_apprenticeship
             course_educators: course_educators
             news: news
             exercise: exercise
-            page: page
             course: course
           group: 1
           exposed: false
@@ -1701,6 +1704,4 @@ display:
         - 'user.node_grants:view'
         - user.roles
       tags:
-        - 'config:domain.config.api_os2udoglaer_dk.da.field.storage.node.field_domain_access'
-        - 'config:domain.config.api_os2udoglaer_dk.field.storage.node.field_domain_access'
         - 'config:field.storage.node.field_domain_access'

--- a/config/sync/views.view.content_search.yml
+++ b/config/sync/views.view.content_search.yml
@@ -841,6 +841,44 @@ display:
             - field_youth_education_subject_name
             - title
             - uid_name
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/config/sync/views.view.content_search.yml
+++ b/config/sync/views.view.content_search.yml
@@ -528,6 +528,360 @@ display:
       tags:
         - 'config:search_api.index.search'
         - 'search_api_list:search'
+  block_10:
+    id: block_10
+    display_title: 'Blok - Juniormesterlære'
+    display_plugin: block
+    position: 1
+    display_options:
+      title: Juniormesterlærer
+      sorts:
+        field_open_for_application:
+          id: field_open_for_application
+          table: search_api_index_search
+          field: field_open_for_application
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        created:
+          id: created
+          table: search_api_index_search
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: Nyeste
+            field_identifier: created
+          exposed: true
+        search_api_relevance:
+          id: search_api_relevance
+          table: search_api_index_search
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: 'Mest relevante'
+            field_identifier: relevance
+          exposed: true
+        title:
+          id: title
+          table: search_api_index_search
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: ASC
+          expose:
+            label: Alfabetisk
+            field_identifier: title
+          exposed: true
+      filters:
+        search_api_datasource:
+          id: search_api_datasource
+          table: search_api_index_search
+          field: search_api_datasource
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_datasource
+          operator: or
+          value:
+            'entity:node': 'entity:node'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        type:
+          id: type
+          table: search_api_index_search
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            junior_apprenticeship: junior_apprenticeship
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        status:
+          id: status
+          table: search_api_index_search
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        current_all:
+          id: current_all
+          table: search_api_index_search
+          field: current_all
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: domain_access_search_api_current_all_filter
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_search
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Søg
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_string
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              webmaster: '0'
+              editor: '0'
+              course_provider: '0'
+              corporation: '0'
+              institution: '0'
+              school: '0'
+              place_of_visit: '0'
+              theater_contact: '0'
+              monitor: '0'
+              bypass_workflow: '0'
+              rest_api: '0'
+            expose_fields: false
+            placeholder: ''
+            searched_fields_id: search_api_fulltext_searched_fields
+            value_maxlength: 128
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields:
+            - body
+            - body_1
+            - field_accordion_headline
+            - field_accordion_items
+            - field_ackground_knowledge
+            - field_activities
+            - field_activity_select_name
+            - field_appetizer_headline
+            - field_appetizer_text
+            - field_areas_of_interest_name
+            - field_course_type_name
+            - field_curriculum_themes_name
+            - field_description
+            - field_educators_target_group_name
+            - field_expectations
+            - field_how_to
+            - field_industry_name
+            - field_name
+            - field_post_processing
+            - field_preparation
+            - field_presentation
+            - field_primary_school_subject_name
+            - field_purpose
+            - field_purpose_exercise
+            - field_quote_text
+            - field_related_user_field_name
+            - field_subject_name
+            - field_sustainability_goals_name
+            - field_text
+            - field_theme_name
+            - field_trgt_grp_daycare_name
+            - field_trgt_grp_primary_school_name
+            - field_trgt_grp_youth_education_name
+            - field_youth_education_subject_name
+            - title
+            - uid_name
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        title: false
+        sorts: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders:
+        os2uol_search:
+          os2uol_search_result_string: 'Viser @count juniormesterlærer'
+        transform_api_facets:
+          transform_facets:
+            junior_apprenticeship_areas_of_interest: junior_apprenticeship_areas_of_interest
+            junior_apprenticeship_company: junior_apprenticeship_company
+            junior_apprenticeship_industry: junior_apprenticeship_industry
+            junior_apprenticeship_open_for_application: junior_apprenticeship_open_for_application
+            junior_apprenticeship_post_number_and_city: junior_apprenticeship_post_number_and_city
+            junior_apprenticeship_company_guarantee_partner: 0
+        transform_api_views:
+          row_transform: entity
+          row_transform_mode: search_result
+          pager_transform: basic
+          pager_transform_links: relative
+          pager_transform_links_destination: current
+      block_description: 'Søg - Juniormesterlære'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - url.site
+        - 'user.node_grants:view'
+      tags:
+        - 'config:search_api.index.search'
+        - 'search_api_list:search'
   block_2:
     id: block_2
     display_title: 'Blok - Kursus'

--- a/config/sync/views.view.content_search.yml
+++ b/config/sync/views.view.content_search.yml
@@ -495,8 +495,305 @@ display:
     position: 1
     display_options:
       title: Erhvervspraktikker
+      filters:
+        search_api_datasource:
+          id: search_api_datasource
+          table: search_api_index_search
+          field: search_api_datasource
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_datasource
+          operator: or
+          value:
+            'entity:node': 'entity:node'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        type:
+          id: type
+          table: search_api_index_search
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            internship: internship
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        status:
+          id: status
+          table: search_api_index_search
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        current_all:
+          id: current_all
+          table: search_api_index_search
+          field: current_all
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: domain_access_search_api_current_all_filter
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_search
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Søg
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_string
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              webmaster: '0'
+              editor: '0'
+              course_provider: '0'
+              corporation: '0'
+              institution: '0'
+              school: '0'
+              place_of_visit: '0'
+              theater_contact: '0'
+              monitor: '0'
+              bypass_workflow: '0'
+              rest_api: '0'
+            expose_fields: false
+            placeholder: ''
+            searched_fields_id: search_api_fulltext_searched_fields
+            value_maxlength: 128
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields:
+            - body
+            - body_1
+            - field_accordion_headline
+            - field_accordion_items
+            - field_ackground_knowledge
+            - field_activities
+            - field_activity_select_name
+            - field_appetizer_headline
+            - field_appetizer_text
+            - field_areas_of_interest_name
+            - field_course_type_name
+            - field_curriculum_themes_name
+            - field_description
+            - field_educators_target_group_name
+            - field_expectations
+            - field_how_to
+            - field_industry_name
+            - field_name
+            - field_post_processing
+            - field_preparation
+            - field_presentation
+            - field_primary_school_subject_name
+            - field_purpose
+            - field_purpose_exercise
+            - field_quote_text
+            - field_related_user_field_name
+            - field_subject_name
+            - field_sustainability_goals_name
+            - field_text
+            - field_theme_name
+            - field_trgt_grp_daycare_name
+            - field_trgt_grp_primary_school_name
+            - field_trgt_grp_youth_education_name
+            - field_youth_education_subject_name
+            - title
+            - uid_name
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       defaults:
         title: false
+        filters: false
+        filter_groups: false
       display_description: ''
       display_extenders:
         os2uol_search:
@@ -1276,6 +1573,44 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -1581,6 +1916,44 @@ display:
             - field_youth_education_subject_name
             - title
             - uid_name
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -2018,6 +2391,44 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -2367,6 +2778,44 @@ display:
             - field_youth_education_subject_name
             - title
             - uid_name
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -2799,6 +3248,44 @@ display:
             min_placeholder: ''
             max_placeholder: ''
             placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
           is_grouped: false
           group_info:
             label: ''
@@ -3255,6 +3742,44 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -3604,6 +4129,44 @@ display:
             - field_youth_education_subject_name
             - title
             - uid_name
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -3953,6 +4516,44 @@ display:
             - field_youth_education_subject_name
             - title
             - uid_name
+        field_exclude_from_search:
+          id: field_exclude_from_search
+          table: search_api_index_search
+          field: field_exclude_from_search
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/config/sync/views.view.school_budget_overview.yml
+++ b/config/sync/views.view.school_budget_overview.yml
@@ -546,11 +546,14 @@ display:
           fieldset_one:
             data_field:
               field_allocated_budget: field_allocated_budget
-              field_rfc_granted_amount: field_rfc_granted_amount
+              field_views_simple_math_field: field_views_simple_math_field
+              uid: 0
               name: 0
               field_allocated_budget_year: 0
-              field_views_simple_math_field: 0
-            formula: '(@field_allocated_budget - @field_rfc_granted_amount + abs(@field_allocated_budget - @field_rfc_granted_amount)) / 2'
+              field_rfc_date: 0
+              field_rfc_granted_amount: 0
+              field_views_simple_math_field_2: 0
+            formula: '@field_allocated_budget - @field_views_simple_math_field'
           mute_logs: false
           set_precision: 0
           precision: '0'

--- a/config/sync/workflows.workflow.editorial.yml
+++ b/config/sync/workflows.workflow.editorial.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.course_educators
     - node.type.exercise
     - node.type.internship
+    - node.type.junior_apprenticeship
     - node.type.news
   module:
     - content_moderation_bypass
@@ -128,5 +129,6 @@ type_settings:
       - course_educators
       - exercise
       - internship
+      - junior_apprenticeship
       - news
   default_moderation_state: draft

--- a/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
+++ b/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
@@ -581,6 +581,12 @@ function os2uol_application_forms_mail_alter(&$message) {
     // Dynamically set the Reply-To header based on workflow type.
     os2uol_application_forms_set_reply_to($entity, $message);
   }
+
+  // Ensure password reset emails are explicitly set to text/plain
+  // to prevent HTML code from being displayed in the email
+  if ($message['id'] === 'user_password_reset') {
+    $message['headers']['Content-Type'] = 'text/plain; charset=UTF-8; format=flowed';
+  }
 }
 
 /**

--- a/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
+++ b/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
@@ -442,6 +442,33 @@ function os2uol_application_forms_entity_presave(Drupal\Core\Entity\EntityInterf
       $entity->set('field_rfc_payment_date', $current_timestamp);
     }
   }
+  
+  // Fix for UOLOS2-420: Ensure field updates are saved even when moderation state doesn't change
+  // This is particularly important for the "Annulleret" (cancelled) state
+  if ($entity instanceof \Drupal\node\Entity\Node && 
+      ($entity->bundle() === 'theater_refund' || $entity->bundle() === 'free_course_request')) {
+    
+    // Check if we have an original entity (updating existing node)
+    if (isset($entity->original)) {
+      $original_state = $entity->original->get('moderation_state')->getString();
+      $new_state = $entity->get('moderation_state')->getString();
+      
+      // If the state is "cancelled" and remains "cancelled", ensure changes are properly saved
+      if ($original_state === 'cancelled' && $new_state === 'cancelled') {
+        // Force a new revision to ensure field changes are captured
+        $entity->setNewRevision(TRUE);
+        $entity->setRevisionCreationTime(time());
+        
+        // Set revision log message to track this update
+        if ($entity->hasField('revision_log')) {
+          $entity->setRevisionLogMessage('Updated fields while maintaining cancelled status');
+        }
+        
+        // Ensure the entity is marked as changed to trigger cache invalidation
+        $entity->setChangedTime(time());
+      }
+    }
+  }
 
   // Prevent content_moderation_notifications from sending emails if field_rfc_send_mail is set to 0.
   if ($entity instanceof \Drupal\node\Entity\Node && $entity->hasField('field_rfc_send_mail')) {
@@ -474,6 +501,32 @@ function os2uol_application_forms_entity_update(\Drupal\Core\Entity\EntityInterf
     if ($session->get(Os2Notification::NO_EMAIL_SESSION_VARIABLE)) {
       $session->remove(Os2Notification::NO_EMAIL_SESSION_VARIABLE);
       $session->save();
+    }
+  }
+  
+  // Fix for UOLOS2-420: Invalidate cache tags for application forms to ensure list views are updated
+  if ($entity instanceof \Drupal\node\Entity\Node && 
+      ($entity->bundle() === 'theater_refund' || $entity->bundle() === 'free_course_request')) {
+    
+    // Check if we're updating from cancelled to cancelled state
+    if (isset($entity->original)) {
+      $original_state = $entity->original->get('moderation_state')->getString();
+      $new_state = $entity->get('moderation_state')->getString();
+      
+      if ($original_state === 'cancelled' && $new_state === 'cancelled') {
+        // Invalidate specific cache tags to ensure views are refreshed
+        \Drupal\Core\Cache\Cache::invalidateTags([
+          'node:' . $entity->id(),
+          'node_list:' . $entity->bundle(),
+          'views_data:' . $entity->bundle(),
+        ]);
+        
+        // Log the cache invalidation for debugging
+        \Drupal::logger('os2uol_application_forms')->info('Cache invalidated for @type node @nid after cancelled->cancelled update', [
+          '@type' => $entity->bundle(),
+          '@nid' => $entity->id(),
+        ]);
+      }
     }
   }
 }

--- a/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
+++ b/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
@@ -581,43 +581,6 @@ function os2uol_application_forms_mail_alter(&$message) {
     // Dynamically set the Reply-To header based on workflow type.
     os2uol_application_forms_set_reply_to($entity, $message);
   }
-
-  // Ensure all core user emails are explicitly set to text/plain
-  // to prevent HTML code from being displayed in the email.
-  // This fixes the issue where symfony_mailer_lite forces HTML format
-  // but SMTP module with smtp_allowhtml:false shows raw HTML tags.
-  $core_user_mail_types = [
-    'user_password_reset',
-    'user_cancel_confirm', 
-    'user_register_admin_created',
-    'user_register_no_approval_required',
-    'user_register_pending_approval',
-    'user_register_pending_approval_admin',
-    'user_status_activated',
-    'user_status_blocked',
-    'user_status_canceled'
-  ];
-  
-  if (in_array($message['id'], $core_user_mail_types)) {
-    $message['headers']['Content-Type'] = 'text/plain; charset=UTF-8; format=flowed';
-    
-    // Force plain text format to prevent symfony_mailer_lite from converting to HTML
-    $message['params']['content_type'] = 'text/plain';
-    
-    // Convert any HTML that might have been added back to plain text
-    // This handles cases where the body has already been processed
-    if (is_array($message['body'])) {
-      foreach ($message['body'] as &$body_part) {
-        // Remove any HTML tags that may have been added
-        if (is_string($body_part) && strip_tags($body_part) !== $body_part) {
-          // Use Drupal's MailFormatHelper to properly convert HTML to text
-          $body_part = \Drupal\Core\Mail\MailFormatHelper::htmlToText($body_part);
-        }
-      }
-    } elseif (is_string($message['body']) && strip_tags($message['body']) !== $message['body']) {
-      $message['body'] = \Drupal\Core\Mail\MailFormatHelper::htmlToText($message['body']);
-    }
-  }
 }
 
 /**

--- a/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
+++ b/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
@@ -582,10 +582,41 @@ function os2uol_application_forms_mail_alter(&$message) {
     os2uol_application_forms_set_reply_to($entity, $message);
   }
 
-  // Ensure password reset emails are explicitly set to text/plain
-  // to prevent HTML code from being displayed in the email
-  if ($message['id'] === 'user_password_reset') {
+  // Ensure all core user emails are explicitly set to text/plain
+  // to prevent HTML code from being displayed in the email.
+  // This fixes the issue where symfony_mailer_lite forces HTML format
+  // but SMTP module with smtp_allowhtml:false shows raw HTML tags.
+  $core_user_mail_types = [
+    'user_password_reset',
+    'user_cancel_confirm', 
+    'user_register_admin_created',
+    'user_register_no_approval_required',
+    'user_register_pending_approval',
+    'user_register_pending_approval_admin',
+    'user_status_activated',
+    'user_status_blocked',
+    'user_status_canceled'
+  ];
+  
+  if (in_array($message['id'], $core_user_mail_types)) {
     $message['headers']['Content-Type'] = 'text/plain; charset=UTF-8; format=flowed';
+    
+    // Force plain text format to prevent symfony_mailer_lite from converting to HTML
+    $message['params']['content_type'] = 'text/plain';
+    
+    // Convert any HTML that might have been added back to plain text
+    // This handles cases where the body has already been processed
+    if (is_array($message['body'])) {
+      foreach ($message['body'] as &$body_part) {
+        // Remove any HTML tags that may have been added
+        if (is_string($body_part) && strip_tags($body_part) !== $body_part) {
+          // Use Drupal's MailFormatHelper to properly convert HTML to text
+          $body_part = \Drupal\Core\Mail\MailFormatHelper::htmlToText($body_part);
+        }
+      }
+    } elseif (is_string($message['body']) && strip_tags($message['body']) !== $message['body']) {
+      $message['body'] = \Drupal\Core\Mail\MailFormatHelper::htmlToText($message['body']);
+    }
   }
 }
 

--- a/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
+++ b/webroot/modules/custom/os2uol_application_forms/os2uol_application_forms.module
@@ -581,6 +581,43 @@ function os2uol_application_forms_mail_alter(&$message) {
     // Dynamically set the Reply-To header based on workflow type.
     os2uol_application_forms_set_reply_to($entity, $message);
   }
+
+  // Ensure all core user emails are explicitly set to text/plain
+  // to prevent HTML code from being displayed in the email.
+  // This fixes the issue where symfony_mailer_lite forces HTML format
+  // but SMTP module with smtp_allowhtml:false shows raw HTML tags.
+  $core_user_mail_types = [
+    'user_password_reset',
+    'user_cancel_confirm',
+    'user_register_admin_created',
+    'user_register_no_approval_required',
+    'user_register_pending_approval',
+    'user_register_pending_approval_admin',
+    'user_status_activated',
+    'user_status_blocked',
+    'user_status_canceled'
+  ];
+
+  if (in_array($message['id'], $core_user_mail_types)) {
+    $message['headers']['Content-Type'] = 'text/plain; charset=UTF-8; format=flowed';
+
+    // Force plain text format to prevent symfony_mailer_lite from converting to HTML
+    $message['params']['content_type'] = 'text/plain';
+
+    // Convert any HTML that might have been added back to plain text
+    // This handles cases where the body has already been processed
+    if (is_array($message['body'])) {
+      foreach ($message['body'] as &$body_part) {
+        // Remove any HTML tags that may have been added
+        if (is_string($body_part) && strip_tags($body_part) !== $body_part) {
+          // Use Drupal's MailFormatHelper to properly convert HTML to text
+          $body_part = \Drupal\Core\Mail\MailFormatHelper::htmlToText($body_part);
+        }
+      }
+    } elseif (is_string($message['body']) && strip_tags($message['body']) !== $message['body']) {
+      $message['body'] = \Drupal\Core\Mail\MailFormatHelper::htmlToText($message['body']);
+    }
+  }
 }
 
 /**

--- a/webroot/modules/custom/os2uol_entity_forms/os2uol_entity_forms.module
+++ b/webroot/modules/custom/os2uol_entity_forms/os2uol_entity_forms.module
@@ -23,7 +23,7 @@ function os2uol_entity_forms_field_widget_single_element_paragraphs_form_alter(&
     $paragraph_type = $element['#paragraph_type'];
 
     // Now you can use the node type to conditionally alter the paragraph field.
-    if ($node_type == 'internship' && $paragraph_type == 'material') {
+    if (in_array($node_type, ['internship', 'junior_apprenticeship']) && $paragraph_type == 'material') {
       // Disable the field 'field_literature_suggestion'
       $element['subform']['field_literature_suggestion']['#access'] = FALSE;
     }
@@ -44,6 +44,7 @@ function os2uol_entity_forms_form_alter(&$form, FormStateInterface $form_state, 
     'node_course_educators_form',
     'node_exercise_form',
     'node_internship_form',
+    'node_junior_apprenticeship_form',
     'node_news_form',
     'node_page_form'
   ];
@@ -53,6 +54,7 @@ function os2uol_entity_forms_form_alter(&$form, FormStateInterface $form_state, 
     'node_course_educators_edit_form',
     'node_exercise_edit_form',
     'node_internship_edit_form',
+    'node_junior_apprenticeship_edit_form',
     'node_news_edit_form',
     'node_page_edit_form'
   ];
@@ -174,7 +176,9 @@ function os2uol_entity_forms_form_alter(&$form, FormStateInterface $form_state, 
   // Define form IDs for internship forms.
   $internship_form_ids = [
     'node_internship_form',
-    'node_internship_edit_form'
+    'node_junior_apprenticeship_form',
+    'node_internship_edit_form',
+    'node_junior_apprenticeship_edit_form'
   ];
 
   // Hide the time part of the application deadline date field for internship forms.


### PR DESCRIPTION
This pull request introduces a new form display configuration for junior apprenticeships, updates field placements and groupings in existing form displays, and makes minor adjustments to hostnames and documentation. The main focus is on improving the organization and visibility of fields within Drupal entity forms, especially for the new `pretix_settings` mode.

**New configuration and major form display changes:**
* Added a new file `config/sync/core.entity_form_display.node.junior_apprenticeship.pretix_settings.yml` to support a dedicated form mode for junior apprenticeships, including extensive field groupings, conditional logic, and visibility settings.
* In `config/sync/core.entity_form_display.node.exercise.default.yml`, reorganized field groupings and field weights, notably moving `field_purpose_exercise` to a different section and adjusting its display order. [[1]](diffhunk://
* Updated field order and grouping in `config/sync/core.entity_form_display.node.transport_pool_form.default.yml`, including reordering `field_rfc_name`, `field_rfc_phone`, and `field_tpf_message` for improved logical flow. [[1]](diffhunk://

**Other changes:**
* Added `udoglaer.roskilde.os2udoglaer` to the list of additional hostnames in `.ddev/config.yaml` to support a new environment.
* Updated the deployment count in the documentation (`README.md`) to reflect the latest deploy.